### PR TITLE
UHF-2723 prevent translation override

### DIFF
--- a/src/Commands/LocaleCommands.php
+++ b/src/Commands/LocaleCommands.php
@@ -153,7 +153,6 @@ class LocaleCommands extends DrushCommands {
           'drush',
           'locale:import',
           '--type=customized',
-          '--override=all',
           $language->getId(),
           $file->uri,
         ]);


### PR DESCRIPTION
Prevents overriding existing translations when drush helfi:locale-import command is executed.