### PR TITLE
UHF-2689: Do not change existing menu item to match the entity status

### DIFF
--- a/src/Entity/Form/MenuLinkFormTrait.php
+++ b/src/Entity/Form/MenuLinkFormTrait.php
@@ -187,8 +187,11 @@ trait MenuLinkFormTrait {
       }
     }
     if (!empty($values['enabled'])) {
-      // Menu link inherits published status from parent entity.
-      $entity->isPublished() ? $menu_link->setPublished() : $menu_link->setUnpublished();
+      if ($menu_link->isNew() || $menu_link->isNewTranslation()) {
+        // If the menu link is a new one, it inherits published status from
+        // parent entity.
+        $entity->isPublished() ? $menu_link->setPublished() : $menu_link->setUnpublished();
+      }
 
       [$menu_name, $parent] = explode(':', $values['menu_parent'], 2);
 


### PR DESCRIPTION
Previously, when updating TPR service or unit, the menu item's status was also updated to match the entity's published status. As there were many intentionally disabled menu items for published services and units, those menu items were inadvertently enabled.

Now the menu item status matches the entity's status only for new menu items and new translations.

**How to test**

* Set up a local environment.
* Make sure you some imported TPR units and services.
* Open the Edit main navigation page (`/admin/structure/menu/manage/main`) to view the current menu items.
* Go to he Unit (`admin/content/integrations/tpr-unit`) and Service lists (`/admin/content/integrations/tpr-service`) to select some units and services to edit. When editing the units and services, pay attention to its published status and menu settings.
* Check that these apply:
  * For a _published_ entity that's _not_ currently in the menu: the new menu item should be _enabled_.
  * For an _unpublished_ entity that's _not_ currently in the menu: the new menu item should be _disabled_.
  * For a _published_ or _unpublished_ entity that currently _has_ a _disabled_ or _enabled_ menu item: there shouldn't be any change for the menu item status when saving the entity.