### PR TITLE
UHF-4788: Rest endpoint to check helfi package versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1']
+        php-versions: ['8.0']
     container:
       image: ghcr.io/city-of-helsinki/drupal-php-docker:${{ matrix.php-versions }}-alpine
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ env:
   SIMPLETEST_BASE_URL: "http://127.0.0.1:8888"
   DRUPAL_CORE_VERSION: 9.3.x
   SYMFONY_DEPRECATIONS_HELPER: disabled
+  BROWSERTEST_OUTPUT_DIRECTORY: 'sites/simpletest'
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -30,8 +31,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set variables
+      - name: Set Drupal root
         run: echo "DRUPAL_ROOT=$HOME/drupal" >> $GITHUB_ENV
+
+      - name: Set module folder
+        run: echo "MODULE_FOLDER=$DRUPAL_ROOT/modules/contrib/${{ secrets.MODULE_NAME }}" >> $GITHUB_ENV
 
       - name: Clone drupal
         run: git clone --depth 1 --branch "$DRUPAL_CORE_VERSION" http://git.drupal.org/project/drupal.git/ $DRUPAL_ROOT
@@ -46,6 +50,7 @@ jobs:
           composer run-script drupal-phpunit-upgrade
           composer require "drush/drush ^10.0"
           composer config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+          composer require --dev donatj/mock-webserver
           composer require --dev "drupal/coder"
 
       - name: Install Drupal
@@ -57,11 +62,31 @@ jobs:
       - name: Run PHPCS
         run: |
           cd $DRUPAL_ROOT
-          vendor/bin/phpcs modules/contrib/${{ secrets.MODULE_NAME }} --standard=Drupal --extensions=php,module,inc,install,test,info
+          vendor/bin/phpcs $MODULE_FOLDER --standard=Drupal --extensions=php,module,inc,install,test,info
 
-      - name: Run PHPUnit tests
+      - name: Start services
         run: |
           cd $DRUPAL_ROOT
           vendor/bin/drush runserver $SIMPLETEST_BASE_URL > /dev/null 2>&1 &
           chromedriver --port=4444 > /dev/null 2>&1 &
-          php ./core/scripts/run-tests.sh --dburl $SIMPLETEST_DB --php /usr/local/bin/php --color --verbose --sqlite /tmp/test.sqlite --url $SIMPLETEST_BASE_URL ${{ secrets.MODULE_NAME }}
+
+      - name: Run PHPUnit tests
+        run: |
+          cd $DRUPAL_ROOT
+          php -d pcov.directory=$MODULE_FOLDER \
+            vendor/bin/phpunit \
+            --bootstrap $DRUPAL_ROOT/core/tests/bootstrap.php \
+            -c $MODULE_FOLDER/phpunit.xml \
+            --coverage-clover=coverage.xml \
+            $MODULE_FOLDER
+          codecov
+
+      - name: Create an artifact from test report
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: results
+          path: |
+            ${{ env.DRUPAL_ROOT }}/sites/simpletest/browser_output/
+            ${{ env.DRUPAL_ROOT }}/coverage.xml
+          retention-days: 1

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,1 @@
+sonar.exclusions=tests/**

--- a/config/optional/rest.resource.helfi_debug_data.yml
+++ b/config/optional/rest.resource.helfi_debug_data.yml
@@ -1,6 +1,8 @@
 langcode: en
 status: true
-dependencies: { }
+dependencies:
+  module:
+    - user
 id: helfi_debug_data
 plugin_id: 'helfi_debug_data'
 granularity: resource

--- a/config/optional/rest.resource.helfi_debug_package_version.yml
+++ b/config/optional/rest.resource.helfi_debug_package_version.yml
@@ -1,6 +1,8 @@
 langcode: en
 status: true
-dependencies: { }
+dependencies:
+  module:
+    - user
 id: helfi_debug_package_version
 plugin_id: 'helfi_debug_package_version'
 granularity: resource

--- a/config/optional/rest.resource.helfi_debug_package_version.yml
+++ b/config/optional/rest.resource.helfi_debug_package_version.yml
@@ -1,0 +1,13 @@
+langcode: en
+status: true
+dependencies: { }
+id: helfi_debug_package_version
+plugin_id: 'helfi_debug_package_version'
+granularity: resource
+configuration:
+  methods:
+    - GET
+  formats:
+    - json
+  authentication:
+    - cookie

--- a/documentation/debug.md
+++ b/documentation/debug.md
@@ -13,3 +13,14 @@ See [src/Plugin/DebugDataItem/Composer.php](/src/Plugin/DebugDataItem/Composer.p
 At minimum, you need:
 - A plugin class that implements `\Drupal\helfi_debug\DebugDataItemInterface`
 - Create a plugin specific template (`debug-item--{plugin_id}.html.twig`). See [templates/debug-item.html.twig](/templates/debug-item.html.twig) for more information.
+
+## Package version checker
+
+The `/api/v1/version` endpoint can be used to fetch the latest version of a composer package.
+
+For example:
+
+Request `GET /api/v1/version?package=drupal/helfi_api_base&version=1.2.0` will respond with:
+
+- The latest version number
+- Whether the given version is the latest version

--- a/helfi_api_base.install
+++ b/helfi_api_base.install
@@ -54,3 +54,24 @@ function helfi_api_base_update_9002() : void {
   $config_name = 'rest.resource.helfi_debug_data';
   $config_storage->write($config_name, $source->read($config_name));
 }
+
+/**
+ * Install the package version rest config.
+ */
+function helfi_api_base_update_9003() : void {
+  if (!\Drupal::moduleHandler()->moduleExists('rest')) {
+    return;
+  }
+  $config_path = \Drupal::service('extension.list.module')
+      ->getPath('helfi_api_base') . '/config/optional';
+  $source = new FileStorage($config_path);
+  $config_storage = \Drupal::service('config.storage');
+
+  $configs = [
+    'rest.resource.helfi_debug_package_version',
+  ];
+
+  foreach ($configs as $config) {
+    $config_storage->write($config, $source->read($config));
+  }
+}

--- a/helfi_api_base.install
+++ b/helfi_api_base.install
@@ -63,7 +63,7 @@ function helfi_api_base_update_9003() : void {
     return;
   }
   $config_path = \Drupal::service('extension.list.module')
-      ->getPath('helfi_api_base') . '/config/optional';
+    ->getPath('helfi_api_base') . '/config/optional';
   $source = new FileStorage($config_path);
   $config_storage = \Drupal::service('config.storage');
 

--- a/helfi_api_base.services.yml
+++ b/helfi_api_base.services.yml
@@ -33,3 +33,15 @@ services:
   plugin.manager.debug_data_item:
     class: Drupal\helfi_api_base\DebugDataItemPluginManager
     parent: default_plugin_manager
+
+  helfi_api_base.package_version_checker:
+    class: Drupal\helfi_api_base\Package\VersionChecker
+    arguments: []
+    tags:
+      - { name: service_collector, call: add, tag: helfi_api_base.version_checker }
+
+  helfi_api_base.helfi_package_version_checker:
+    class: Drupal\helfi_api_base\Package\HelfiPackage
+    arguments: ['@http_client']
+    tags:
+      - { name: helfi_api_base.version_checker }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+  colors="true"
+  cacheResultFile=".phpunit.cache/test-results"
+  executionOrder="depends,defects"
+  forceCoversAnnotation="true"
+  beStrictAboutTestsThatDoNotTestAnything="true"
+  beStrictAboutOutputDuringTests="true"
+  beStrictAboutChangesToGlobalState="true"
+  beStrictAboutCoversAnnotation="true"
+  printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter"
+  failOnRisky="true"
+  failOnWarning="true"
+  verbose="true">
+<php>
+  <!-- Set error reporting to E_ALL. -->
+  <ini name="error_reporting" value="32767"/>
+    <!-- Do not limit the amount of memory tests take to run. -->
+  <ini name="memory_limit" value="-1"/>
+  <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browserName":"chrome","chromeOptions":{"w3c": false, "args":["--disable-gpu","--headless", "--no-sandbox"]}}, "http://127.0.0.1:4444"]' />
+</php>
+<testsuites>
+  <testsuite name="unit">
+    <directory>./tests/src/Unit</directory>
+  </testsuite>
+  <testsuite name="kernel">
+    <directory>./tests/src/Kernel</directory>
+  </testsuite>
+  <testsuite name="functional">
+    <directory>./tests/src/Functional</directory>
+  </testsuite>
+  <testsuite name="functional-javascript">
+    <directory>./tests/src/FunctionalJavascript</directory>
+  </testsuite>
+</testsuites>
+<listeners>
+  <listener class="\Drupal\Tests\Listeners\DrupalListener">
+  </listener>
+</listeners>
+<coverage cacheDirectory=".phpunit.cache/code-coverage" processUncoveredFiles="true">
+  <include>
+    <directory suffix=".php">./src</directory>
+    <file>./*.module</file>
+  </include>
+</coverage>
+</phpunit>

--- a/src/Exception/InvalidPackageException.php
+++ b/src/Exception/InvalidPackageException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\Exception;
+
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * Exception to indicate invalid package.
+ */
+final class InvalidPackageException extends BadRequestHttpException {
+}

--- a/src/Package/HelfiPackage.php
+++ b/src/Package/HelfiPackage.php
@@ -80,7 +80,7 @@ final class HelfiPackage implements VersionCheckerInterface {
     // Packages are sorted from oldest to newest.
     $latest = end($packages);
 
-    if (!isset($latest['version']) || !is_string($latest['version'])) {
+    if (empty($latest['version']) || !is_string($latest['version'])) {
       throw new InvalidPackageException('No version data found.');
     }
     return new Version($packageName, $latest['version'], version_compare($version, $latest['version'], '>='));

--- a/src/Package/HelfiPackage.php
+++ b/src/Package/HelfiPackage.php
@@ -46,6 +46,7 @@ final class HelfiPackage implements VersionCheckerInterface {
       if (!isset($content['packages'][$packageName])) {
         return NULL;
       }
+      // Packages are sorted from oldest to newest.
       $latest = end($content['packages'][$packageName]);
 
       if (!isset($latest['version']) || !is_string($latest['version'])) {

--- a/src/Package/HelfiPackage.php
+++ b/src/Package/HelfiPackage.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\Package;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\RequestException;
+
+/**
+ * Provides a version checker for helfi custom modules.
+ */
+final class HelfiPackage implements VersionCheckerInterface {
+
+  public const BASE_URL = 'https://repository.drupal.hel.ninja/p2/%s.json';
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param \GuzzleHttp\ClientInterface $client
+   *   The HTTP client.
+   */
+  public function __construct(
+    private ClientInterface $client
+  ) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(string $packageName): bool {
+    // @todo Allow other city-of-helsinki packages too.
+    return str_starts_with($packageName, 'drupal/helfi_')
+      || str_starts_with($packageName, 'drupal/hdbt');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function get(string $packageName, string $version): ? Version {
+    try {
+      $response = $this->client
+        ->request('GET', sprintf(self::BASE_URL, $packageName));
+      $content = json_decode($response->getBody()->getContents(), TRUE);
+
+      if (!isset($content['packages'][$packageName])) {
+        return NULL;
+      }
+      $latest = end($content['packages'][$packageName]);
+
+      if (!isset($latest['version']) || !is_string($latest['version'])) {
+        return NULL;
+      }
+      return new Version($packageName, $latest['version'], version_compare($version, $latest['version'], '>='));
+    }
+    catch (RequestException $e) {
+    }
+    return NULL;
+  }
+
+}

--- a/src/Package/HelfiPackage.php
+++ b/src/Package/HelfiPackage.php
@@ -4,8 +4,9 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_api_base\Package;
 
+use Drupal\helfi_api_base\Exception\InvalidPackageException;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\GuzzleException;
 
 /**
  * Provides a version checker for helfi custom modules.
@@ -35,28 +36,54 @@ final class HelfiPackage implements VersionCheckerInterface {
   }
 
   /**
+   * Gets the package data.
+   *
+   * @param string $packageName
+   *   The package name.
+   * @param bool $dev
+   *   Whether to get dev releases or not.
+   *
+   * @return array
+   *   The packages.
+   *
+   * @throws \Drupal\helfi_api_base\Exception\InvalidPackageException
+   */
+  private function getPackageData(string $packageName, bool $dev = FALSE) : array {
+    $packagePath = $dev ? sprintf('%s~dev', $packageName) : $packageName;
+
+    try {
+      $response = $this->client
+        ->request('GET', sprintf(self::BASE_URL, $packagePath));
+      $content = json_decode($response->getBody()->getContents(), TRUE);
+    }
+    catch (GuzzleException $e) {
+      return [];
+    }
+    if (!isset($content['packages'][$packageName])) {
+      throw new InvalidPackageException('Package not found.');
+    }
+    return $content['packages'][$packageName];
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function get(string $packageName, string $version): ? Version {
-    try {
-      $response = $this->client
-        ->request('GET', sprintf(self::BASE_URL, $packageName));
-      $content = json_decode($response->getBody()->getContents(), TRUE);
-
-      if (!isset($content['packages'][$packageName])) {
-        return NULL;
-      }
-      // Packages are sorted from oldest to newest.
-      $latest = end($content['packages'][$packageName]);
-
-      if (!isset($latest['version']) || !is_string($latest['version'])) {
-        return NULL;
-      }
-      return new Version($packageName, $latest['version'], version_compare($version, $latest['version'], '>='));
+    // Attempt to get package data and fallback to dev version if
+    // no stable version is found.
+    if (!$packages = $this->getPackageData($packageName)) {
+      $packages = $this->getPackageData($packageName, TRUE);
     }
-    catch (RequestException $e) {
+    usort($packages, function ($package1, $package2) {
+      return version_compare($package1['version'], $package2['version']);
+    });
+    // Packages are sorted from oldest to newest.
+    $latest = end($packages);
+
+    if (!isset($latest['version']) || !is_string($latest['version'])) {
+      throw new InvalidPackageException('No version data found.');
     }
-    return NULL;
+    return new Version($packageName, $latest['version'], version_compare($version, $latest['version'], '>='));
   }
 
 }

--- a/src/Package/Version.php
+++ b/src/Package/Version.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\Package;
+
+/**
+ * A value object to store package version data.
+ */
+final class Version {
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param string $name
+   *   The package name.
+   * @param string $latestVersion
+   *   The version.
+   * @param bool $isLatest
+   *   Whether the given version is latest or not.
+   */
+  public function __construct(
+    public string $name,
+    public string $latestVersion,
+    public bool $isLatest,
+  ) {
+  }
+
+  /**
+   * Gets the object as an array.
+   *
+   * @return array
+   *   The data as an array.
+   */
+  public function toArray() : array {
+    return [
+      'name' => $this->name,
+      'latestVersion' => $this->latestVersion,
+      'isLatest' => $this->isLatest,
+    ];
+  }
+
+}

--- a/src/Package/VersionChecker.php
+++ b/src/Package/VersionChecker.php
@@ -40,6 +40,8 @@ final class VersionChecker {
    *
    * @return \Drupal\helfi_api_base\Package\Version|null
    *   The version object or null.
+   *
+   * @throws \Drupal\helfi_api_base\Exception\InvalidPackageException
    */
   public function get(string $packageName, string $version) : ? Version {
     foreach ($this->collectors as $collector) {

--- a/src/Package/VersionChecker.php
+++ b/src/Package/VersionChecker.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\Package;
+
+/**
+ * Provides a package version checker.
+ */
+final class VersionChecker {
+
+  /**
+   * The collectors.
+   *
+   * @var \Drupal\helfi_api_base\Package\VersionCheckerInterface[]
+   */
+  private array $collectors = [];
+
+  /**
+   * Adds a version checker.
+   *
+   * @param \Drupal\helfi_api_base\Package\VersionCheckerInterface $versionChecker
+   *   The version checker collector.
+   *
+   * @return $this
+   *   The self.
+   */
+  public function add(VersionCheckerInterface $versionChecker) : self {
+    $this->collectors[] = $versionChecker;
+    return $this;
+  }
+
+  /**
+   * Gets the package version.
+   *
+   * @param string $packageName
+   *   The package name.
+   * @param string $version
+   *   The version.
+   *
+   * @return \Drupal\helfi_api_base\Package\Version|null
+   *   The version object or null.
+   */
+  public function get(string $packageName, string $version) : ? Version {
+    foreach ($this->collectors as $collector) {
+      if (!$collector->applies($packageName)) {
+        continue;
+      }
+      return $collector->get($packageName, $version);
+    }
+    return NULL;
+  }
+
+}

--- a/src/Package/VersionCheckerInterface.php
+++ b/src/Package/VersionCheckerInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\Package;
+
+/**
+ * Defines the version checker interface.
+ */
+interface VersionCheckerInterface {
+
+  /**
+   * Checks whether this collector is applicable.
+   *
+   * @param string $packageName
+   *   The package name to check.
+   *
+   * @return bool
+   *   TRUE if this instance should handle the version check.
+   */
+  public function applies(string $packageName) : bool;
+
+  /**
+   * Gets the version data.
+   *
+   * @param string $packageName
+   *   The package name.
+   * @param string $version
+   *   The version.
+   *
+   * @return \Drupal\helfi_api_base\Package\Version|null
+   *   The version or null.
+   */
+  public function get(string $packageName, string $version) : ? Version;
+
+}

--- a/src/Package/VersionCheckerInterface.php
+++ b/src/Package/VersionCheckerInterface.php
@@ -30,6 +30,8 @@ interface VersionCheckerInterface {
    *
    * @return \Drupal\helfi_api_base\Package\Version|null
    *   The version or null.
+   *
+   * @throws \Drupal\helfi_api_base\Exception\InvalidPackageException
    */
   public function get(string $packageName, string $version) : ? Version;
 

--- a/src/Plugin/DebugDataItem/Composer.php
+++ b/src/Plugin/DebugDataItem/Composer.php
@@ -33,7 +33,7 @@ class Composer extends DebugDataItemPluginBase implements ContainerFactoryPlugin
    *
    * @var \ComposerLockParser\Package[]
    */
-  private array $packages;
+  private array $packages = [];
 
   /**
    * {@inheritdoc}
@@ -86,6 +86,7 @@ class Composer extends DebugDataItemPluginBase implements ContainerFactoryPlugin
     foreach ($this->getPackages() as $package) {
       $data['packages'][] = [
         'name' => $package->getName(),
+        'source' => $package->getSource(),
         'version' => $package->getVersion(),
         'time' => $package->getTime()?->format('c'),
       ];

--- a/src/Plugin/DebugDataItem/Composer.php
+++ b/src/Plugin/DebugDataItem/Composer.php
@@ -53,7 +53,7 @@ class Composer extends DebugDataItemPluginBase implements ContainerFactoryPlugin
    * @return bool
    *   TRUE if package should be included.
    */
-  public function isValidPackage(string $package) : bool {
+  private function isValidPackage(string $package) : bool {
     return match(TRUE) {
       str_starts_with($package, 'drupal/helfi_'),
       str_starts_with($package, 'drupal/hdbt') => TRUE,
@@ -87,6 +87,7 @@ class Composer extends DebugDataItemPluginBase implements ContainerFactoryPlugin
       $data['packages'][] = [
         'name' => $package->getName(),
         'source' => $package->getSource(),
+
         'version' => $package->getVersion(),
         'time' => $package->getTime()?->format('c'),
       ];

--- a/src/Plugin/DebugDataItem/Composer.php
+++ b/src/Plugin/DebugDataItem/Composer.php
@@ -29,6 +29,13 @@ class Composer extends DebugDataItemPluginBase implements ContainerFactoryPlugin
   private ComposerInfo $composerInfo;
 
   /**
+   * The packages cache.
+   *
+   * @var \ComposerLockParser\Package[]
+   */
+  private array $packages;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
@@ -40,32 +47,43 @@ class Composer extends DebugDataItemPluginBase implements ContainerFactoryPlugin
   /**
    * Checks if package should be included in collection or not.
    *
-   * @param \ComposerLockParser\Package $package
+   * @param string $package
    *   The package.
    *
    * @return bool
    *   TRUE if package should be included.
    */
-  private function includePackage(Package $package) : bool {
+  public function isValidPackage(string $package) : bool {
     return match(TRUE) {
-      str_starts_with($package->getName(), 'drupal/helfi_'),
-      str_starts_with($package->getName(), 'drupal/hdbt') => TRUE,
+      str_starts_with($package, 'drupal/helfi_'),
+      str_starts_with($package, 'drupal/hdbt') => TRUE,
       default => FALSE,
     };
+  }
+
+  /**
+   * Gets the included package.
+   *
+   * @return \ComposerLockParser\Package[]
+   *   The packages.
+   */
+  public function getPackages() : array {
+    if (!$this->packages) {
+      $this->packages = iterator_to_array($this->composerInfo->getPackages());
+    }
+
+    return array_filter($this->packages, function (Package $package) {
+      return $this->isValidPackage($package->getName());
+    });
   }
 
   /**
    * {@inheritdoc}
    */
   public function collect(): array {
-    /** @var \ComposerLockParser\Package[] $packages */
-    $packages = $this->composerInfo->getPackages();
-
     $data = [];
-    foreach ($packages as $package) {
-      if (!$this->includePackage($package)) {
-        continue;
-      }
+
+    foreach ($this->getPackages() as $package) {
       $data['packages'][] = [
         'name' => $package->getName(),
         'version' => $package->getVersion(),

--- a/src/Plugin/rest/resource/DebugDataResource.php
+++ b/src/Plugin/rest/resource/DebugDataResource.php
@@ -42,7 +42,7 @@ final class DebugDataResource extends ResourceBase implements DependentPluginInt
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) : DebugDataResource {
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) : self {
     $instance = parent::create(
       $container,
       $configuration,

--- a/src/Plugin/rest/resource/DebugDataResource.php
+++ b/src/Plugin/rest/resource/DebugDataResource.php
@@ -100,7 +100,9 @@ final class DebugDataResource extends ResourceBase implements DependentPluginInt
    * {@inheritdoc}
    */
   public function calculateDependencies() {
-    $dependencies = [];
+    $dependencies = [
+      'module' => ['user'],
+    ];
 
     foreach ($this->getDataPlugins() as $plugin) {
       foreach ($plugin->calculateDependencies() as $type => $value) {

--- a/src/Plugin/rest/resource/PackageVersion.php
+++ b/src/Plugin/rest/resource/PackageVersion.php
@@ -90,8 +90,9 @@ final class PackageVersion extends ResourceBase implements DependentPluginInterf
    * {@inheritdoc}
    */
   public function calculateDependencies() {
-    $dependencies = [];
-    return $dependencies;
+    return [
+      'module' => ['user'],
+    ];
   }
 
 }

--- a/src/Plugin/rest/resource/PackageVersion.php
+++ b/src/Plugin/rest/resource/PackageVersion.php
@@ -65,7 +65,7 @@ final class PackageVersion extends ResourceBase implements DependentPluginInterf
       if (is_array($value)) {
         $value = reset($value);
       }
-      $args[$arg] = $value;
+      $args[$arg] = (string) $value;
     }
     ['name' => $name, 'version' => $version] = $args;
 

--- a/src/Plugin/rest/resource/PackageVersion.php
+++ b/src/Plugin/rest/resource/PackageVersion.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\Plugin\rest\resource;
+
+use Drupal\Component\Plugin\DependentPluginInterface;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\helfi_api_base\Package\Version;
+use Drupal\helfi_api_base\Package\VersionChecker;
+use Drupal\rest\Plugin\ResourceBase;
+use Drupal\rest\ResourceResponse;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * Represents Package version as resources.
+ *
+ * @RestResource(
+ *   id = "helfi_debug_package_version",
+ *   label = @Translation("Package version"),
+ *   uri_paths = {
+ *     "canonical" = "/api/v1/package"
+ *   }
+ * )
+ */
+final class PackageVersion extends ResourceBase implements DependentPluginInterface {
+
+  /**
+   * The version checker service.
+   *
+   * @var \Drupal\helfi_api_base\Package\VersionChecker
+   */
+  private VersionChecker $packageVersion;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) : self {
+    $instance = parent::create(
+      $container,
+      $configuration,
+      $plugin_id,
+      $plugin_definition
+    );
+    $instance->packageVersion = $container->get('helfi_api_base.package_version_checker');
+    return $instance;
+  }
+
+  /**
+   * Responds to GET requests.
+   *
+   * @return \Drupal\rest\ResourceResponse
+   *   The response containing the record.
+   *
+   * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+   */
+  public function get(Request $request) : ResourceResponse {
+    $args = [];
+    foreach (['name', 'version'] as $arg) {
+      if (!$value = $request->query->get($arg)) {
+        throw new BadRequestHttpException(sprintf('Missing required query argument: %s', $arg));
+      }
+      if (is_array($value)) {
+        $value = reset($value);
+      }
+      $args[$arg] = $value;
+    }
+    ['name' => $name, 'version' => $version] = $args;
+
+    $data = $this->packageVersion->get($name, $version);
+
+    if (!$data instanceof Version) {
+      throw new BadRequestHttpException(sprintf('Invalid package name: %s', $name));
+    }
+
+    $cacheableMetadata = new CacheableMetadata();
+    $cacheableMetadata->addCacheContexts([
+      'url.query_args:name',
+      'url.query_args:version',
+    ])
+      ->setCacheMaxAge(180);
+
+    return (new ResourceResponse($data->toArray()))
+      ->addCacheableDependency($cacheableMetadata);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function calculateDependencies() {
+    $dependencies = [];
+    return $dependencies;
+  }
+
+}

--- a/tests/src/Kernel/ApiKernelTestBase.php
+++ b/tests/src/Kernel/ApiKernelTestBase.php
@@ -4,13 +4,18 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\helfi_api_base\Kernel;
 
+use Drupal\Component\Serialization\Json;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceModifierInterface;
 use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
 use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * API test base.
  */
-abstract class ApiKernelTestBase extends EntityKernelTestBase {
+abstract class ApiKernelTestBase extends EntityKernelTestBase implements ServiceModifierInterface {
 
   use ApiTestTrait;
 
@@ -28,6 +33,56 @@ abstract class ApiKernelTestBase extends EntityKernelTestBase {
     parent::setUp();
 
     $this->installConfig(['helfi_api_base']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container) {
+  }
+
+  /**
+   * Process a request.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   *   The response.
+   */
+  protected function processRequest(Request $request): Response {
+    return $this->container->get('http_kernel')->handle($request);
+  }
+
+  /**
+   * Creates a request object.
+   *
+   * @param string $uri
+   *   The uri.
+   * @param string $method
+   *   The method.
+   * @param array $parameters
+   *   The parameters.
+   * @param array $document
+   *   The document.
+   *
+   * @return \Symfony\Component\HttpFoundation\Request
+   *   The request.
+   */
+  protected function getMockedRequest(
+    string $uri,
+    string $method = 'GET',
+    array $parameters = [],
+    array $document = []
+  ): Request {
+    $document = $document ? Json::encode($document) : NULL;
+
+    $request = Request::create($uri, $method, $parameters, [], [], [], $document ? Json::encode($document) : NULL);
+    if ($document !== []) {
+      $request->headers->set('Content-Type', 'application/json');
+    }
+    $request->headers->set('Accept', 'application/json');
+    return $request;
   }
 
 }

--- a/tests/src/Kernel/Plugin/rest/resource/PackageVersionTest.php
+++ b/tests/src/Kernel/Plugin/rest/resource/PackageVersionTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_api_base\Kernel\Plugin\rest\resource;
+
+use Drupal\Core\Cache\CacheableResponse;
+use Drupal\helfi_api_base\Package\HelfiPackage;
+use Drupal\Tests\helfi_api_base\Kernel\ApiKernelTestBase;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
+
+/**
+ * Tests the entity_changed plugin.
+ *
+ * @coversDefaultClass \Drupal\helfi_api_base\Plugin\rest\resource\PackageVersion
+ * @group helfi_api_base
+ */
+class PackageVersionTest extends ApiKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'migrate',
+    'serialization',
+    'rest',
+  ];
+
+  /**
+   * Creates a user with correct permissions.
+   */
+  private function setupUser() : void {
+    $user = $this->createUser(permissions: ['restful get helfi_debug_package_version']);
+    $this->drupalSetCurrentUser($user);
+  }
+
+  /**
+   * Tests request without permission.
+   */
+  public function testAccessDenied() : void {
+    $this->drupalSetUpCurrentUser();
+
+    $request = $this->getMockedRequest('/api/v1/package');
+    $response = $this->processRequest($request);
+
+    $this->assertEquals(HttpResponse::HTTP_FORBIDDEN, $response->getStatusCode());
+  }
+
+  /**
+   * Tests required query parameters.
+   *
+   * @dataProvider getDataRequiredParameters
+   */
+  public function testGetRequiredParameters(array $parameters, string $expectedErrorMessage) : void {
+    $this->setupUser();
+    $request = $this->getMockedRequest('/api/v1/package', parameters: $parameters);
+    $response = $this->processRequest($request);
+
+    $this->assertEquals(HttpResponse::HTTP_BAD_REQUEST, $response->getStatusCode());
+    $this->assertEquals($expectedErrorMessage, json_decode($response->getContent(), TRUE)['message']);
+  }
+
+  /**
+   * A data provider.
+   *
+   * @return array[]
+   *   The data.
+   */
+  public function getDataRequiredParameters() : array {
+    return [
+      [
+        [], 'Missing required query argument: name',
+      ],
+      [
+        ['name' => 'drupal/helfi_api_base'], 'Missing required query argument: version',
+      ],
+    ];
+  }
+
+  /**
+   * Tests invalid package name.
+   */
+  public function testInvalidPackageName() : void {
+    $this->setupUser();
+    $request = $this->getMockedRequest('/api/v1/package', parameters: [
+      'name' => 'drupal/invalid',
+      'version' => '1.0.0',
+    ]);
+    $response = $this->processRequest($request);
+
+    $this->assertEquals(HttpResponse::HTTP_BAD_REQUEST, $response->getStatusCode());
+    $this->assertEquals('Invalid package name: drupal/invalid', json_decode($response->getContent(), TRUE)['message']);
+  }
+
+  /**
+   * Tests requests that lead to InvalidPackageException error.
+   */
+  public function testInvalidPackageException() : void {
+    \Drupal::service('kernel')->rebuildContainer();
+
+    $client = $this->createMockHttpClient([
+      new RequestException('message', new Request('GET', 'test')),
+      new RequestException('message', new Request('GET', 'test')),
+    ]);
+    $this->container->set('helfi_api_base.helfi_package_version_checker', new HelfiPackage($client));
+
+    $request = $this->getMockedRequest('/api/v1/package', parameters: [
+      'name' => 'drupal/helfi_api_base',
+      'version' => '1.0.0',
+    ]);
+
+    $this->setupUser();
+    $response = $this->processRequest($request);
+
+    $this->assertEquals(HttpResponse::HTTP_BAD_REQUEST, $response->getStatusCode());
+    $this->assertEquals('No version data found.', json_decode($response->getContent(), TRUE)['message']);
+  }
+
+  /**
+   * Tests get request and cache contexts.
+   */
+  public function testGet() : void {
+    \Drupal::service('kernel')->rebuildContainer();
+    $client = $this->createMockHttpClient([
+      new Response(body: json_encode([
+        'packages' => [
+          'drupal/helfi_api_base' => [
+            [
+              'version' => '1.2.0',
+            ],
+          ],
+        ],
+      ])),
+    ]);
+    $this->container->set('helfi_api_base.helfi_package_version_checker', new HelfiPackage($client));
+
+    $request = $this->getMockedRequest('/api/v1/package', parameters: [
+      'name' => 'drupal/helfi_api_base',
+      'version' => '1.0.0',
+    ]);
+    $this->setupUser();
+    $response = $this->processRequest($request);
+
+    $this->assertInstanceOf(CacheableResponse::class, $response);
+    // Make sure our response is not sent to actual API.
+    $this->assertEquals('1.2.0', json_decode($response->getContent(), TRUE)['latestVersion']);
+    $this->assertContains('url.query_args:name', $response->getCacheableMetadata()->getCacheContexts());
+    $this->assertContains('url.query_args:version', $response->getCacheableMetadata()->getCacheContexts());
+    $this->assertEquals(180, $response->getCacheableMetadata()->getCacheMaxAge());
+  }
+
+}

--- a/tests/src/Traits/ApiTestTrait.php
+++ b/tests/src/Traits/ApiTestTrait.php
@@ -17,7 +17,7 @@ trait ApiTestTrait {
   /**
    * Creates HTTP client stub.
    *
-   * @param \Psr\Http\Message\ResponseInterface[] $responses
+   * @param \Psr\Http\Message\ResponseInterface[]|\GuzzleHttp\Exception\GuzzleException[] $responses
    *   The expected responses.
    *
    * @return \GuzzleHttp\Client

--- a/tests/src/Unit/ComposerDataItemTest.php
+++ b/tests/src/Unit/ComposerDataItemTest.php
@@ -76,7 +76,7 @@ class ComposerDataItemTest extends UnitTestCase {
               'time' => '2022-01-31T13:21:47+00:00',
               'source' => [
                 'type' => 'git',
-                'url' => 'http://test/drupal-helfi-tpr',
+                'url' => 'https://test/drupal-helfi-tpr',
                 'reference' => '123',
               ],
             ],
@@ -85,7 +85,7 @@ class ComposerDataItemTest extends UnitTestCase {
               'version' => '2.0.2',
               'time' => '2022-01-30T10:21:47+00:00',
               'source' => [
-                'url' => 'http://test/hdbt-admin.git',
+                'url' => 'https://test/hdbt-admin.git',
               ],
             ],
           ],
@@ -95,7 +95,7 @@ class ComposerDataItemTest extends UnitTestCase {
             'name' => 'drupal/helfi_tpr',
             'source' => [
               'type' => 'git',
-              'url' => 'http://test/drupal-helfi-tpr',
+              'url' => 'https://test/drupal-helfi-tpr',
               'reference' => '123',
             ],
             'version' => '2.0.1',
@@ -104,7 +104,7 @@ class ComposerDataItemTest extends UnitTestCase {
           [
             'name' => 'drupal/helfi_hdbt_admin',
             'source' => [
-              'url' => 'http://test/hdbt-admin.git',
+              'url' => 'https://test/hdbt-admin.git',
             ],
             'version' => '2.0.2',
             'time' => '2022-01-30T10:21:47+00:00',

--- a/tests/src/Unit/ComposerDataItemTest.php
+++ b/tests/src/Unit/ComposerDataItemTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\helfi_api_base\Unit;
 
 use ComposerLockParser\ComposerInfo;
 use ComposerLockParser\Package;
+use ComposerLockParser\PackagesCollection;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\helfi_api_base\Plugin\DebugDataItem\Composer;
 use Drupal\Tests\UnitTestCase;
@@ -28,13 +29,14 @@ class ComposerDataItemTest extends UnitTestCase {
    *   The container builder.
    */
   private function getContainer(array $packages) : ContainerBuilder {
+    $collection = new PackagesCollection(array_map(
+      fn(array $package) => Package::factory($package),
+      $packages
+    ));
     $composerInfo = $this->prophesize(ComposerInfo::class);
     $composerInfo
       ->getPackages()
-      ->willReturn(array_map(
-        fn(array $package) => Package::factory($package),
-        $packages
-      ));
+      ->willReturn($collection);
 
     $container = new ContainerBuilder();
     $container->set('helfi_api_base.composer_info', $composerInfo->reveal());
@@ -43,6 +45,11 @@ class ComposerDataItemTest extends UnitTestCase {
 
   /**
    * Tests collect method.
+   *
+   * @covers ::collect
+   * @covers ::isValidPackage
+   * @covers ::getPackages
+   * @covers ::create
    *
    * @dataProvider collectionDataProvider
    */
@@ -67,22 +74,38 @@ class ComposerDataItemTest extends UnitTestCase {
               'name' => 'drupal/helfi_tpr',
               'version' => '2.0.1',
               'time' => '2022-01-31T13:21:47+00:00',
+              'source' => [
+                'type' => 'git',
+                'url' => 'http://test/drupal-helfi-tpr',
+                'reference' => '123',
+              ],
             ],
             [
               'name' => 'drupal/helfi_hdbt_admin',
               'version' => '2.0.2',
               'time' => '2022-01-30T10:21:47+00:00',
+              'source' => [
+                'url' => 'http://test/hdbt-admin.git',
+              ],
             ],
           ],
         ],
         [
           [
             'name' => 'drupal/helfi_tpr',
+            'source' => [
+              'type' => 'git',
+              'url' => 'http://test/drupal-helfi-tpr',
+              'reference' => '123',
+            ],
             'version' => '2.0.1',
             'time' => '2022-01-31T13:21:47+00:00',
           ],
           [
             'name' => 'drupal/helfi_hdbt_admin',
+            'source' => [
+              'url' => 'http://test/hdbt-admin.git',
+            ],
             'version' => '2.0.2',
             'time' => '2022-01-30T10:21:47+00:00',
           ],

--- a/tests/src/Unit/DebugDataResourceDependencyTest.php
+++ b/tests/src/Unit/DebugDataResourceDependencyTest.php
@@ -67,6 +67,8 @@ class DebugDataResourceDependencyTest extends UnitTestCase {
 
   /**
    * Tests that dependencies are populated.
+   *
+   * @covers ::calculateDependencies
    */
   public function testDependencies() : void {
     $pluginManager = $this->prophesize(DebugDataItemPluginManager::class);
@@ -80,12 +82,12 @@ class DebugDataResourceDependencyTest extends UnitTestCase {
         'config' => ['user.role.anonymous'],
         'theme' => ['seven'],
         'content' => ['node:article:f0a189e6-55fb-47fb-8005-5bef81c44d6d'],
-        'modules' => ['node', 'user'],
+        'module' => ['node'],
       ]));
     $pluginManager->createInstance('test2')
       ->willReturn($this->getDataItemPlugin([
         'config' => ['user.role.authenticated'],
-        'modules' => ['user', 'helfi_api_base'],
+        'module' => ['helfi_api_base'],
       ]));
     $logger = $this->prophesize(LoggerInterface::class);
     $loggerFactory = $this->prophesize(LoggerChannelFactoryInterface::class);
@@ -102,7 +104,7 @@ class DebugDataResourceDependencyTest extends UnitTestCase {
       'config' => ['user.role.anonymous', 'user.role.authenticated'],
       'theme' => ['seven'],
       'content' => ['node:article:f0a189e6-55fb-47fb-8005-5bef81c44d6d'],
-      'modules' => ['node', 'user', 'helfi_api_base'],
+      'module' => ['user', 'node', 'helfi_api_base'],
     ], $sut->calculateDependencies());
   }
 

--- a/tests/src/Unit/DebugDataResourceDependencyTest.php
+++ b/tests/src/Unit/DebugDataResourceDependencyTest.php
@@ -69,6 +69,8 @@ class DebugDataResourceDependencyTest extends UnitTestCase {
    * Tests that dependencies are populated.
    *
    * @covers ::calculateDependencies
+   * @covers ::create
+   * @covers ::getDataPlugins
    */
   public function testDependencies() : void {
     $pluginManager = $this->prophesize(DebugDataItemPluginManager::class);

--- a/tests/src/Unit/InternalDomainResolverTest.php
+++ b/tests/src/Unit/InternalDomainResolverTest.php
@@ -34,6 +34,7 @@ class InternalDomainResolverTest extends UnitTestCase {
    *
    * @dataProvider isExternalData
    * @covers ::isExternal
+   * @covers ::__construct
    */
   public function testIsExternal(string $url, bool $expectedExternal) : void {
     $url = Url::fromUri($url);

--- a/tests/src/Unit/InternalDomainResolverTest.php
+++ b/tests/src/Unit/InternalDomainResolverTest.php
@@ -33,6 +33,7 @@ class InternalDomainResolverTest extends UnitTestCase {
    * Tests whether the url is external or not.
    *
    * @dataProvider isExternalData
+   * @covers ::isExternal
    */
   public function testIsExternal(string $url, bool $expectedExternal) : void {
     $url = Url::fromUri($url);

--- a/tests/src/Unit/Package/HelfiPackageTest.php
+++ b/tests/src/Unit/Package/HelfiPackageTest.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_api_base\Unit\Package;
+
+use Drupal\helfi_api_base\Package\HelfiPackage;
+use Drupal\helfi_api_base\Package\Version;
+use Drupal\Tests\UnitTestCase;
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * Tests Helfi package collector.
+ *
+ * @coversDefaultClass \Drupal\helfi_api_base\Package\HelfiPackage
+ * @group helfi_api_base
+ */
+class HelfiPackageTest extends UnitTestCase {
+
+  /**
+   * Creates an HTTP client.
+   *
+   * @param \GuzzleHttp\Psr7\Response[]|\GuzzleHttp\Exception\RequestException[] $responses
+   *   The responses.
+   *
+   * @return \GuzzleHttp\ClientInterface
+   *   The client.
+   */
+  private function createClient(array $responses) : ClientInterface {
+    $mock = new MockHandler($responses);
+    $handler = HandlerStack::create($mock);
+    return new Client(['handler' => $handler]);
+  }
+
+  /**
+   * Tests applies().
+   *
+   * @covers ::applies
+   * @covers ::__construct
+   * @dataProvider appliesData
+   */
+  public function testApplies(string $package, bool $expected) : void {
+    $sut = new HelfiPackage($this->prophesize(ClientInterface::class)->reveal());
+    $this->assertEquals($expected, $sut->applies($package));
+  }
+
+  /**
+   * Data provider for applies() test.
+   *
+   * @return array[]
+   *   The data.
+   */
+  public function appliesData() : array {
+    return [
+      ['drupal/helfi_api_base', TRUE],
+      ['drupal/hdbt', TRUE],
+      ['drupal/hdbt_admin', TRUE],
+      ['city-of-helsinki/hauki', FALSE],
+    ];
+  }
+
+  /**
+   * Tests empty version.
+   *
+   * @covers ::get
+   * @covers ::__construct
+   * @dataProvider emptyVersionData
+   */
+  public function testEmptyVersion($version) : void {
+    $client = $this->createClient([
+      new Response(body: json_encode([
+        'packages' => [
+          [
+            'drupal/helfi_api_base' => [
+              [
+                'version' => $version,
+              ],
+            ],
+          ],
+        ],
+      ])),
+    ]);
+    $sut = new HelfiPackage($client);
+    $this->assertNull($sut->get('drupal/helfi_api_base', '1.2.0'));
+  }
+
+  /**
+   * Data provider for empty version check.
+   *
+   * @return array
+   *   The data.
+   */
+  public function emptyVersionData() : array {
+    return [
+      [NULL],
+      [1],
+      [''],
+    ];
+  }
+
+  /**
+   * Tests that client error returns null.
+   *
+   * @covers ::get
+   * @covers ::__construct
+   */
+  public function testException() : void {
+    $client = $this->createClient([
+      new RequestException('some error', new Request('GET', 'test')),
+    ]);
+    $sut = new HelfiPackage($client);
+    $this->assertNull($sut->get('drupal/helfi_api_base', '1.2.0'));
+  }
+
+  /**
+   * Tests empty packages.
+   *
+   * @covers ::get
+   * @covers ::__construct
+   */
+  public function testEmptyPackage() : void {
+    $client = $this->createClient([
+      new Response(body: json_encode([
+        'packages' => [],
+      ])),
+    ]);
+    $sut = new HelfiPackage($client);
+    $this->assertNull($sut->get('drupal/helfi_api_base', '1.2.0'));
+  }
+
+  /**
+   * Tests get().
+   *
+   * @covers ::__construct
+   * @covers ::get
+   * @covers \Drupal\helfi_api_base\Package\Version
+   *
+   * @dataProvider getData
+   */
+  public function testGet(
+    string $packageName,
+    array $packageVersions,
+    string $packageVersion,
+    string $expectedLatestVersion,
+    bool $isLatest
+  ) : void {
+    $client = $this->createClient([
+      new Response(body: json_encode([
+        'packages' => [
+          $packageName => $packageVersions,
+        ],
+      ])),
+    ]);
+    $sut = new HelfiPackage($client);
+    $result = $sut->get($packageName, $packageVersion);
+    $this->assertInstanceOf(Version::class, $result);
+    $this->assertEquals($packageName, $result->name);
+    $this->assertEquals($expectedLatestVersion, $result->latestVersion);
+    $this->assertEquals($isLatest, $result->isLatest);
+  }
+
+  /**
+   * Data provider for get().
+   *
+   * @return array[]
+   *   The data.
+   */
+  public function getData() : array {
+    return [
+      // Test with same version.
+      [
+        'drupal/helfi_api_base',
+        [
+          [
+            'version' => '1.2.0',
+          ],
+          [
+            'version' => '1.3.0',
+          ],
+        ],
+        '1.3.0',
+        '1.3.0',
+        TRUE,
+      ],
+      // Test with future release.
+      [
+        'drupal/helfi_api_base',
+        [
+          [
+            'version' => '1.2.0',
+          ],
+          [
+            'version' => '1.3.0',
+          ],
+        ],
+        '1.4.0',
+        '1.3.0',
+        TRUE,
+      ],
+      // Test older release.
+      [
+        'drupal/hdbt',
+        [
+          [
+            'version' => '1.2.0',
+          ],
+          [
+            'version' => '1.3.0',
+          ],
+        ],
+        '1.2.0',
+        '1.3.0',
+        FALSE,
+      ],
+    ];
+  }
+
+}

--- a/tests/src/Unit/Package/HelfiPackageTest.php
+++ b/tests/src/Unit/Package/HelfiPackageTest.php
@@ -72,7 +72,7 @@ class HelfiPackageTest extends UnitTestCase {
     ]);
     $sut = new HelfiPackage($client);
     $this->expectException(InvalidPackageException::class);
-    $this->expectExceptionMessage('Package not found.');
+    $this->expectExceptionMessage('No version data found.');
     $sut->get('drupal/helfi_api_base', '1.2.0');
   }
 
@@ -95,6 +95,7 @@ class HelfiPackageTest extends UnitTestCase {
    *
    * @covers ::get
    * @covers ::__construct
+   * @covers ::getPackageData
    */
   public function testException() : void {
     // First we try to fetch stable version, then fallback to dev.
@@ -113,6 +114,7 @@ class HelfiPackageTest extends UnitTestCase {
    *
    * @covers ::get
    * @covers ::__construct
+   * @covers ::getPackageData
    */
   public function testEmptyPackage() : void {
     $client = $this->createMockHttpClient([
@@ -132,6 +134,7 @@ class HelfiPackageTest extends UnitTestCase {
    * @covers ::__construct
    * @covers ::get
    * @covers \Drupal\helfi_api_base\Package\Version
+   * @covers ::getPackageData
    *
    * @dataProvider getData
    */

--- a/tests/src/Unit/Package/HelfiPackageTest.php
+++ b/tests/src/Unit/Package/HelfiPackageTest.php
@@ -56,6 +56,7 @@ class HelfiPackageTest extends UnitTestCase {
    *
    * @covers ::get
    * @covers ::__construct
+   * @covers ::getPackageData
    * @dataProvider emptyVersionData
    */
   public function testEmptyVersion($version) : void {


### PR DESCRIPTION
To test this:

- Run `composer require drupal/helfi_api_base:dev-UHF-4788`
- Run `drush updb`
- Send request to `/api/v1/package?name=drupal/helfi_api_base&version=2.1.1`
