### PR TITLE
UHF-5041: Stdout logger

### DIFF
--- a/helfi_api_base.install
+++ b/helfi_api_base.install
@@ -75,3 +75,12 @@ function helfi_api_base_update_9003() : void {
     $config_storage->write($config, $source->read($config));
   }
 }
+
+/**
+ * Disable syslog module.
+ */
+function helfi_api_base_update_9004() : void {
+  \Drupal::service('module_installer')->uninstall([
+    'syslog',
+  ]);
+}

--- a/helfi_api_base.services.yml
+++ b/helfi_api_base.services.yml
@@ -45,3 +45,9 @@ services:
     arguments: ['@http_client']
     tags:
       - { name: helfi_api_base.version_checker }
+
+  helfi_api_base.stdout_logger:
+    class: Drupal\helfi_api_base\Logger\StdOut
+    arguments: ['@logger.log_message_parser']
+    tags:
+      - { name: logger }

--- a/src/Logger/StdOut.php
+++ b/src/Logger/StdOut.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\Logger;
+
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
+use Drupal\Core\Logger\LogMessageParserInterface;
+use Drupal\Core\Logger\RfcLoggerTrait;
+use Drupal\Core\Logger\RfcLogLevel;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Provides a 'stdout' logger.
+ */
+final class StdOut implements LoggerInterface {
+
+  use RfcLoggerTrait;
+  use DependencySerializationTrait;
+
+  /**
+   * Gets the log message.
+   *
+   * @param \Drupal\Core\Logger\LogMessageParserInterface $parser
+   *   The log message parser.
+   */
+  public function __construct(private LogMessageParserInterface $parser) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function log($level, $message, array $context = []) : void {
+    global $base_url;
+
+    $file = $level <= RfcLogLevel::WARNING ? 'php://stderr' : 'php://stdout';
+    $stream = fopen($file, 'w');
+
+    // Populate the message placeholders and then replace them in the message.
+    $variables = $this->parser->parseMessagePlaceholders($message, $context);
+    $message = empty($variables) ? $message : strtr($message, $variables);
+
+    $entry = strtr('!base_url|!timestamp|!type|!ip|!request_uri|!referer|!uid|!link|!message', [
+      '!base_url' => $base_url,
+      '!timestamp' => $context['timestamp'],
+      '!type' => $context['channel'],
+      '!ip' => $context['ip'],
+      '!request_uri' => $context['request_uri'],
+      '!referer' => $context['referer'],
+      '!severity' => $level,
+      '!uid' => $context['uid'],
+      '!link' => strip_tags($context['link']),
+      '!message' => strip_tags($message),
+    ]);
+
+    fwrite($stream, $entry . "\r\n");
+    fclose($stream);
+  }
+
+}


### PR DESCRIPTION
To test this:

- `composer require drupal/helfi_api_base:dev-UHF-5041` or if that doesn't work: `composer reinstall --prefer-source drupal/helfi_api_base` and then checkout the `UHF-5041` branch in `public/modules/contrib/helfi_api_base`.
- `drush cr`

You can test this by adding `\Drupal::logger('helfi_api_base')->error('Something');` to `src/Controller/DebugController.php` file and then opening the `/admin/debug` page. 

Verify that the error message is sent to container logs: `docker compose logs app`. For example:
```
helfi-kymp-app  | [30-Mar-2022 07:38:38] WARNING: [pool www] child 45 said into stderr: "https://helfi-proxy.docker.so|1648625918|helfi_api_base|192.168.64.11|https://helfi-proxy.docker.so/fi/kaupunkiymparisto-ja-liikenne/admin/content|https://helfi-pr
"xy.docker.so/fi/kaupunkiymparisto-ja-liikenne/user/1/edit|1||Something
```