### PR TITLE
Add environment and instance name to response headers

### DIFF
--- a/config/schema/helfi_api_base.schema.yml
+++ b/config/schema/helfi_api_base.schema.yml
@@ -3,7 +3,7 @@ action.configuration.remote_entity:migration_update:*:
   label: 'Update given remote entity'
 
 helfi_api_base.environment_resolver.settings:
-  type: mapping
+  type: config_entity
   mapping:
     environment_name:
       type: string

--- a/helfi_api_base.services.yml
+++ b/helfi_api_base.services.yml
@@ -50,3 +50,9 @@ services:
     arguments: ['@http_client']
     tags:
       - { name: helfi_api_base.version_checker }
+
+  helfi_api_base.environment_response_subscriber:
+    class: Drupal\helfi_api_base\EventSubscriber\EnvironmentResponseSubscriber
+    arguments: ['@helfi_api_base.environment_resolver']
+    tags:
+      - { name: event_subscriber }

--- a/src/EventSubscriber/EnvironmentResponseSubscriber.php
+++ b/src/EventSubscriber/EnvironmentResponseSubscriber.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\EventSubscriber;
+
+use Drupal\helfi_api_base\Environment\EnvironmentResolver;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Adds current instance and environment name to response headers.
+ */
+final class EnvironmentResponseSubscriber implements EventSubscriberInterface {
+
+  public const INSTANCE_HEADER_NAME = 'X-Drupal-Instance';
+  public const ENVIRONMENT_HEADER_NAME = 'X-Drupal-Environment';
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param \Drupal\helfi_api_base\Environment\EnvironmentResolver $environmentResolver
+   *   The environment resolver.
+   */
+  public function __construct(
+    private EnvironmentResolver $environmentResolver
+  ) {
+  }
+
+  /**
+   * Responds to kernel response event.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
+   *   The event to respond to.
+   */
+  public function onResponse(ResponseEvent $event) : void {
+    $response = $event->getResponse();
+
+    try {
+      $environment = $this->environmentResolver
+        ->getActiveEnvironment();
+      $response->headers->add([self::INSTANCE_HEADER_NAME => $environment->getId()]);
+      $response->headers->add([self::ENVIRONMENT_HEADER_NAME => $environment->getEnvironmentName()]);
+    }
+    catch (\InvalidArgumentException) {
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() : array {
+    $events[KernelEvents::RESPONSE][] = ['onResponse'];
+
+    return $events;
+  }
+
+}

--- a/tests/src/Kernel/EnvironmentResponseSubscriberTest.php
+++ b/tests/src/Kernel/EnvironmentResponseSubscriberTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_api_base\Kernel;
+
+use Drupal\Core\Render\HtmlResponse;
+use Drupal\helfi_api_base\EventSubscriber\EnvironmentResponseSubscriber;
+use Drupal\KernelTests\KernelTestBase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * Tests environment response headers.
+ *
+ * @coversDefaultClass \Drupal\helfi_api_base\EventSubscriber\EnvironmentResponseSubscriber
+ * @group helfi_api_base
+ */
+class EnvironmentResponseSubscriberTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['helfi_api_base'];
+
+  /**
+   * Gets the response subscriber service.
+   *
+   * @return \Drupal\helfi_api_base\EventSubscriber\EnvironmentResponseSubscriber
+   *   The response subscriber.
+   */
+  private function getSut() : EnvironmentResponseSubscriber {
+    return $this->container->get('helfi_api_base.environment_response_subscriber');
+  }
+
+  /**
+   * Gets the mock response event.
+   *
+   * @return \Symfony\Component\HttpKernel\Event\ResponseEvent
+   *   The response event.
+   */
+  private function getResponseEvent(Request $request = NULL) : ResponseEvent {
+    if (!$request) {
+      $request = Request::createFromGlobals();
+    }
+    return new ResponseEvent(
+      $this->container->get('http_kernel'),
+      $request,
+      HttpKernelInterface::MASTER_REQUEST,
+      new HtmlResponse()
+    );
+  }
+
+  /**
+   * Asserts that response has no header when project is not defined.
+   */
+  public function testNoResponseHeader() : void {
+    $event = $this->getResponseEvent();
+    $this->getSut()->onResponse($event);
+    $this->assertNotContains(EnvironmentResponseSubscriber::ENVIRONMENT_HEADER_NAME, $event->getResponse()->headers);
+    $this->assertNotContains(EnvironmentResponseSubscriber::INSTANCE_HEADER_NAME, $event->getResponse()->headers);
+  }
+
+  /**
+   * Asserts that response headers are set when project name is defined.
+   */
+  public function testHeadersExist() : void {
+    $this->config('helfi_api_base.environment_resolver.settings')
+      ->set('environment_name', 'dev')
+      ->set('project_name', 'liikenne')
+      ->save();
+
+    $event = $this->getResponseEvent();
+    $this->getSut()->onResponse($event);
+    $this->assertEquals('dev', $event->getResponse()->headers->get(EnvironmentResponseSubscriber::ENVIRONMENT_HEADER_NAME));
+    $this->assertEquals('liikenne', $event->getResponse()->headers->get(EnvironmentResponseSubscriber::INSTANCE_HEADER_NAME));
+  }
+
+}


### PR DESCRIPTION
To test this:

- `composer require drupal/helfi_api_base:dev-UHF-X-add-environment-to-response`
- `drush cr`

Check response headers (devtools network tab) and make sure X-Drupal-Instance and X-Drupal-Environment headers are set.