### PR TITLE
Added enum to list all available environment names, maintenance mode debug plugin, API account mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Base module for `drupal-helfi-platform` ecosystem.
 
 ## Features
 
-- [API credential manager](documentation/api-accounts.md): Allows API credentials to be created/managed from an environment variable.
+- [API user manager](documentation/api-accounts.md): Allows API users to be created/managed from an environment variable.
 - [Debug collector](documentation/debug.md): A plugin to collect and show various debug information in one place.
 - [Deploy hooks](documentation/deploy-hooks.md): Allows custom tasks to be defined that are run before or after deployment.
 - [Environment resolver](documentation/environment-resolver.md): A service to fetch metadata for given project.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Base module for `drupal-helfi-platform` ecosystem.
 
 ## Features
 
-- [Environment API accounts](documentation/api-accounts.md): Allows API accounts to be mapped from an environment variable.
+- [API credential manager](documentation/api-accounts.md): Allows API credentials to be created/managed from an environment variable.
 - [Debug collector](documentation/debug.md): A plugin to collect and show various debug information in one place.
 - [Deploy hooks](documentation/deploy-hooks.md): Allows custom tasks to be defined that are run before or after deployment.
 - [Environment resolver](documentation/environment-resolver.md): A service to fetch metadata for given project.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Base module for `drupal-helfi-platform` ecosystem.
 
 ## Features
 
+- [Environment API accounts](documentation/api-accounts.md): Allows API accounts to be mapped from an environment variable.
 - [Debug collector](documentation/debug.md): A plugin to collect and show various debug information in one place.
+- [Deploy hooks](documentation/deploy-hooks.md): Allows custom tasks to be defined that are run before or after deployment.
 - [Environment resolver](documentation/environment-resolver.md): A service to fetch metadata for given project.
 - [Logging](documentation/logging.md): Log to Docker container stdout.
 - [Link text filter](documentation/link.md): A custom `filter` plugin to scan and parse external links

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "drupal/entity": "^1.0",
         "drupal/filelog": "^2.1",
         "drupal/health_check": "^3.0",

--- a/config/optional/rest.resource.helfi_debug_data.yml
+++ b/config/optional/rest.resource.helfi_debug_data.yml
@@ -13,3 +13,4 @@ configuration:
     - json
   authentication:
     - cookie
+    - basic_auth

--- a/config/optional/rest.resource.helfi_debug_package_version.yml
+++ b/config/optional/rest.resource.helfi_debug_package_version.yml
@@ -13,3 +13,4 @@ configuration:
     - json
   authentication:
     - cookie
+    - basic_auth

--- a/config/schema/helfi_api_base.schema.yml
+++ b/config/schema/helfi_api_base.schema.yml
@@ -2,6 +2,23 @@ action.configuration.remote_entity:migration_update:*:
   type: action_configuration_default
   label: 'Update given remote entity'
 
+helfi_api_base.api_accounts:
+  type: config_object
+  mapping:
+    accounts:
+      type: sequence
+      sequence:
+        type: mapping
+        mapping:
+          username:
+            type: string
+          password:
+            type: string
+          roles:
+            type: sequence
+            sequence:
+              type: string
+
 helfi_api_base.environment_resolver.settings:
   type: config_entity
   mapping:

--- a/documentation/api-accounts.md
+++ b/documentation/api-accounts.md
@@ -1,0 +1,13 @@
+# API account mapper
+
+Allows API accounts to be created from defined environment variables. The accounts are processed by `drush helfi:post-deploy` command during the deployment.
+
+## Mapping accounts
+
+Define an environment variable starting with `DRUPAL_API_ACCOUNT_`. For example `DRUPAL_API_ACCOUNT_MENU`. These are mapped in [settings.php](https://github.com/City-of-Helsinki/drupal-helfi-platform/blob/main/public/sites/default/settings.php) file shipped with `City-of-Helsinki/drupal-helfi-platform`.
+
+The value should be a JSON string that contains required `username`, `password` and an optional `roles`:
+
+```json
+{"username": "menu-api", "password": "your-password", "roles": ["role1", "role2"]}
+```

--- a/documentation/api-accounts.md
+++ b/documentation/api-accounts.md
@@ -1,13 +1,13 @@
 # API account mapper
 
-Allows API accounts to be created from defined environment variables. The accounts are processed by `drush helfi:post-deploy` command during the deployment.
+Allows API accounts to be created from an environment variable. The accounts are processed by `drush helfi:post-deploy` command during the deployment.
 
 ## Mapping accounts
 
-Define an environment variable starting with `DRUPAL_API_ACCOUNT_`. For example `DRUPAL_API_ACCOUNT_MENU`. These are mapped in [settings.php](https://github.com/City-of-Helsinki/drupal-helfi-platform/blob/main/public/sites/default/settings.php) file shipped with `City-of-Helsinki/drupal-helfi-platform`.
+Define an environment variable called `DRUPAL_API_ACCOUNTS`. These accounts are read and mapped in [settings.php](https://github.com/City-of-Helsinki/drupal-helfi-platform/blob/main/public/sites/default/settings.php) file shipped with `City-of-Helsinki/drupal-helfi-platform`.
 
-The value should be a JSON string that contains required `username`, `password` and an optional `roles`:
+The value should be a JSON string that contains an array of `username`, `password` and an optional `roles` pairs:
 
-```json
-{"username": "menu-api", "password": "your-password", "roles": ["role1", "role2"]}
+```bash
+DRUPAL_API_ACCOUNTS='[{"username":"account1","password":"password1","roles":["role1","role2"]},{"username":"account2","password":"password2"}]'
 ```

--- a/documentation/api-accounts.md
+++ b/documentation/api-accounts.md
@@ -1,6 +1,8 @@
-# API account mapper
+# API user manager
 
-Allows API accounts to be created from an environment variable. The accounts are processed by `drush helfi:post-deploy` command during the deployment.
+Allows API user credentials to be specified in an environment variable.
+
+This can be used to ensure that API users always retain the same credentials, i.e. it creates any missing accounts and then force resets the password.
 
 ## Mapping accounts
 
@@ -11,3 +13,5 @@ The value should be a JSON string that contains an array of `username`, `passwor
 ```bash
 DRUPAL_API_ACCOUNTS='[{"username":"account1","password":"password1","roles":["role1","role2"]},{"username":"account2","password":"password2"}]'
 ```
+
+We hook into `helfi_api_base.post_deploy` event ([src/EventSubscriber/EnsureApiAccountsSubscriber.php](/src/EventSubscriber/EnsureApiAccountsSubscriber.php)), triggered by `drush helfi:post-deploy` command executed as a part of deployment tasks: [https://github.com/City-of-Helsinki/drupal-helfi-platform/blob/main/docker/openshift/entrypoints/20-deploy.sh](https://github.com/City-of-Helsinki/drupal-helfi-platform/blob/main/docker/openshift/entrypoints/20-deploy.sh)

--- a/documentation/deploy-hooks.md
+++ b/documentation/deploy-hooks.md
@@ -1,0 +1,55 @@
+# Deploy hooks
+
+The module defines two Drush commands called `helfi:pre-deploy` and `helfi:post-deploy`. These are first and last things to be run during the deployment. See https://github.com/City-of-Helsinki/drupal-helfi-platform/blob/main/docker/openshift/entrypoints/20-deploy.sh
+
+## Defining deploy tasks
+
+Add a new event subscriber:
+
+```yml
+# yourmodule/yourmodule.services.yml
+  helfi_api_base.your_deploy_hook_subscriber:
+    class: Drupal\helfi_api_base\EventSubscriber\YourDeployHookSubscriber
+    arguments: []
+    tags:
+      - { name: event_subscriber }
+```
+
+```php
+# yourmodule/src/EventSubscriber/YourDeployHookSubscriber.php
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Handles deploy tasks.
+ */
+final class YourDeployHookSubscriber extends DeployHookEventSubscriberBase {
+
+  /**
+   * Responds to 'helfi_api_base.post_deploy' event.
+   *
+   * @param \Symfony\Contracts\EventDispatcher\Event $event
+   *   The event.
+   */
+  public function onPostDeploy(Event $event) : void {
+    // Do something on after deployment.
+  }
+
+  /**
+   * Responds to 'helfi_api_base.pre_deploy' event.
+   *
+   * @param \Symfony\Contracts\EventDispatcher\Event $event
+   *   The event.
+   */
+  public function onPreDeploy(Event $event) : void {
+    // Do something before deployment.
+  }
+
+}
+```

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -1,4 +1,9 @@
 services:
+  helfi_api_base.deploy_commands:
+    class: \Drupal\helfi_api_base\Commands\DeployCommands
+    arguments: ['@event_dispatcher']
+    tags:
+      - { name: drush.command }
   helfi_api_base.fixture_commands:
     class: \Drupal\helfi_api_base\Commands\FixtureCommands
     arguments: ['@service_container']

--- a/helfi_api_base.install
+++ b/helfi_api_base.install
@@ -12,7 +12,7 @@ use Drupal\Core\Config\FileStorage;
 /**
  * Implements hook_install().
  */
-function helfi_api_base_install() {
+function helfi_api_base_install() : void {
   if (\Drupal::moduleHandler()->moduleExists('filter')) {
     $formatters = \Drupal::entityTypeManager()
       ->getStorage('filter_format')
@@ -111,4 +111,11 @@ function helfi_api_base_update_9007() : void {
       'health_check',
     ]);
   }
+}
+
+/**
+ * Create 'debug_api' role if configured so.
+ */
+function helfi_api_base_update_9008() : void {
+  helfi_api_base_modules_installed([], FALSE);
 }

--- a/helfi_api_base.install
+++ b/helfi_api_base.install
@@ -8,13 +8,14 @@
 declare(strict_types = 1);
 
 use Drupal\Core\Config\FileStorage;
+use Drupal\rest\Entity\RestResourceConfig;
 
 /**
  * Implements hook_install().
  */
 function helfi_api_base_install() : void {
-  if (\Drupal::moduleHandler()->moduleExists('filter')) {
-    $formatters = \Drupal::entityTypeManager()
+  if (Drupal::moduleHandler()->moduleExists('filter')) {
+    $formatters = Drupal::entityTypeManager()
       ->getStorage('filter_format')
       ->loadMultiple();
 
@@ -39,14 +40,14 @@ function helfi_api_base_update_9001() : void {
  * Install the debug rest config.
  */
 function helfi_api_base_update_9002() : void {
-  if (!\Drupal::moduleHandler()->moduleExists('rest')) {
+  if (!Drupal::moduleHandler()->moduleExists('rest')) {
     return;
   }
   /** @var \Drupal\Core\Extension\ExtensionPathResolver $extensionPathResolver */
-  $extensionPathResolver = \Drupal::service('extension.path.resolver');
+  $extensionPathResolver = Drupal::service('extension.path.resolver');
   $config_path = $extensionPathResolver->getPath('module', 'helfi_api_base') . '/config/optional';
   $source = new FileStorage($config_path);
-  $config_storage = \Drupal::service('config.storage');
+  $config_storage = Drupal::service('config.storage');
 
   // Install rest resource config.
   $config_name = 'rest.resource.helfi_debug_data';
@@ -57,13 +58,13 @@ function helfi_api_base_update_9002() : void {
  * Install the package version rest config.
  */
 function helfi_api_base_update_9003() : void {
-  if (!\Drupal::moduleHandler()->moduleExists('rest')) {
+  if (!Drupal::moduleHandler()->moduleExists('rest')) {
     return;
   }
-  $config_path = \Drupal::service('extension.list.module')
+  $config_path = Drupal::service('extension.list.module')
     ->getPath('helfi_api_base') . '/config/optional';
   $source = new FileStorage($config_path);
-  $config_storage = \Drupal::service('config.storage');
+  $config_storage = Drupal::service('config.storage');
 
   $configs = [
     'rest.resource.helfi_debug_package_version',
@@ -118,4 +119,26 @@ function helfi_api_base_update_9007() : void {
  */
 function helfi_api_base_update_9008() : void {
   helfi_api_base_modules_installed([], FALSE);
+}
+
+/**
+ * Enable basic_auth authentication method for debug endpoints.
+ */
+function helfi_api_base_update_9009() : void {
+  if (Drupal::moduleHandler()->moduleExists('rest')) {
+    Drupal::service('module_installer')->install([
+      'basic_auth',
+    ]);
+
+    $endpoints = RestResourceConfig::loadMultiple([
+      'helfi_debug_data',
+      'helfi_debug_package_version',
+    ]);
+    foreach ($endpoints as $endpoint) {
+      $config = $endpoint->get('configuration');
+      $config['authentication'][] = 'basic_auth';
+      $endpoint->set('configuration', $config);
+      $endpoint->save();
+    }
+  }
 }

--- a/helfi_api_base.module
+++ b/helfi_api_base.module
@@ -8,6 +8,7 @@
 declare(strict_types = 1);
 
 use Drupal\helfi_api_base\Link\LinkProcessor;
+use Drupal\user\Entity\Role;
 
 /**
  * Implements hook_element_info_alter().
@@ -49,4 +50,30 @@ function helfi_api_base_theme_suggestions_debug_item(array $variables) : array {
   $suggestions = [];
   $suggestions[] = 'debug_item__' . strtr($variables['id'], '.', '_');
   return $suggestions;
+}
+
+/**
+ * Implements hook_modules_installed().
+ */
+function helfi_api_base_modules_installed(array $modules, bool $is_syncing) : void {
+  if ($is_syncing) {
+    return;
+  }
+  $apiAccounts = \Drupal::config('helfi_api_base.api_accounts')->get('accounts') ?? [];
+  $hasDebugApiAccount = array_filter($apiAccounts, function (array $account) : bool {
+    return isset($account['roles']) && in_array('debug_api', $account['roles']);
+  });
+
+  // Create 'Debug API' role that has access to Debug data API endpoint if
+  // we have any API accounts defined with 'debug_api' role.
+  if ($hasDebugApiAccount) {
+    if (!$role = Role::load('debug_api')) {
+      $role = Role::create(['label' => 'Debug API', 'id' => 'debug_api']);
+    }
+
+    if (\Drupal::moduleHandler()->moduleExists('rest')) {
+      $role->grantPermission('restful get helfi_debug_data');
+    }
+    $role->save();
+  }
 }

--- a/helfi_api_base.module
+++ b/helfi_api_base.module
@@ -12,7 +12,7 @@ use Drupal\helfi_api_base\Link\LinkProcessor;
 /**
  * Implements hook_element_info_alter().
  */
-function helfi_api_base_element_info_alter(array &$info) {
+function helfi_api_base_element_info_alter(array &$info) : void {
   $info['link']['#pre_render'] = [
     [LinkProcessor::class, 'preRenderLink'],
   ];
@@ -45,7 +45,7 @@ function helfi_api_base_theme() : array {
 /**
  * Implements hook_theme_suggestions_HOOK().
  */
-function helfi_api_base_theme_suggestions_debug_item(array $variables) {
+function helfi_api_base_theme_suggestions_debug_item(array $variables) : array {
   $suggestions = [];
   $suggestions[] = 'debug_item__' . strtr($variables['id'], '.', '_');
   return $suggestions;

--- a/helfi_api_base.services.yml
+++ b/helfi_api_base.services.yml
@@ -59,6 +59,12 @@ services:
     tags:
       - { name: event_subscriber }
 
+  helfi_api_base.ensure_api_accounts_subscriber:
+    class: Drupal\helfi_api_base\EventSubscriber\EnsureApiAccountsSubscriber
+    arguments: ['@entity_type.manager', '@messenger']
+    tags:
+      - { name: event_subscriber }
+
   helfi_api_base.logger_json:
     class: Drupal\helfi_api_base\Logger\JsonLog
     arguments:

--- a/helfi_api_base.services.yml
+++ b/helfi_api_base.services.yml
@@ -61,7 +61,7 @@ services:
 
   helfi_api_base.ensure_api_accounts_subscriber:
     class: Drupal\helfi_api_base\EventSubscriber\EnsureApiAccountsSubscriber
-    arguments: ['@entity_type.manager', '@messenger']
+    arguments: ['@entity_type.manager', '@messenger', '@config.factory']
     tags:
       - { name: event_subscriber }
 

--- a/src/Commands/DeployCommands.php
+++ b/src/Commands/DeployCommands.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\Commands;
+
+use Drush\Attributes\Command;
+use Drush\Commands\DrushCommands;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * A drush command file.
+ */
+final class DeployCommands extends DrushCommands {
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
+   *   The event dispatcher.
+   */
+  public function __construct(
+    private readonly EventDispatcherInterface $eventDispatcher
+  ) {
+    parent::__construct();
+  }
+
+  /**
+   * Runs reusable 'post deploy' hooks.
+   *
+   * These are run after drush deploy command.
+   *
+   * @return int
+   *   The exit code.
+   */
+  #[Command(name: 'helfi:post-deploy')]
+  public function postDeploy() : int {
+    $this->eventDispatcher->dispatch(new Event(), 'helfi_api_base.post_deploy');
+    return DrushCommands::EXIT_SUCCESS;
+  }
+
+  /**
+   * Runs reusable 'pre deploy' hooks.
+   *
+   * These are run before drush deploy command.
+   *
+   * @return int
+   *   The exit code.
+   */
+  #[Command(name: 'helfi:pre-deploy')]
+  public function preDeploy() : int {
+    $this->eventDispatcher->dispatch(new Event(), 'helfi_api_base.pre_deploy');
+    return DrushCommands::EXIT_SUCCESS;
+  }
+
+}

--- a/src/Environment/EnvMapping.php
+++ b/src/Environment/EnvMapping.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\Environment;
+
+enum EnvMapping : string {
+
+  case Local = 'local';
+  case Test = 'test';
+  case Stage = 'stage';
+  case Prod = 'prod';
+
+}

--- a/src/Environment/EnvMapping.php
+++ b/src/Environment/EnvMapping.php
@@ -7,6 +7,7 @@ namespace Drupal\helfi_api_base\Environment;
 enum EnvMapping : string {
 
   case Local = 'local';
+  case Dev = 'dev';
   case Test = 'test';
   case Stage = 'stage';
   case Prod = 'prod';

--- a/src/Environment/EnvMapping.php
+++ b/src/Environment/EnvMapping.php
@@ -15,7 +15,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 enum EnvMapping : string {
 
   case Local = 'local';
-  case Dev = 'dev';
   case Test = 'test';
   case Stage = 'stage';
   case Prod = 'prod';
@@ -29,7 +28,6 @@ enum EnvMapping : string {
   public function label() : TranslatableMarkup {
     return match ($this) {
       self::Local => new TranslatableMarkup('Local'),
-      self::Dev => new TranslatableMarkup('Development'),
       self::Test => new TranslatableMarkup('Testing'),
       self::Stage => new TranslatableMarkup('Staging'),
       self::Prod => new TranslatableMarkup('Production'),

--- a/src/Environment/EnvMapping.php
+++ b/src/Environment/EnvMapping.php
@@ -15,6 +15,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 enum EnvMapping : string {
 
   case Local = 'local';
+  case Dev = 'dev';
   case Test = 'test';
   case Stage = 'stage';
   case Prod = 'prod';
@@ -28,6 +29,7 @@ enum EnvMapping : string {
   public function label() : TranslatableMarkup {
     return match ($this) {
       self::Local => new TranslatableMarkup('Local'),
+      self::Dev => new TranslatableMarkup('Development'),
       self::Test => new TranslatableMarkup('Testing'),
       self::Stage => new TranslatableMarkup('Staging'),
       self::Prod => new TranslatableMarkup('Production'),

--- a/src/Environment/EnvMapping.php
+++ b/src/Environment/EnvMapping.php
@@ -1,9 +1,17 @@
 <?php
 
+// phpcs:ignoreFile
+// @todo remove phpcs ignore once https://www.drupal.org/project/coder/issues/3283741 is fixed.
+
 declare(strict_types = 1);
 
 namespace Drupal\helfi_api_base\Environment;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Enum to contains all available environments.
+ */
 enum EnvMapping : string {
 
   case Local = 'local';
@@ -11,5 +19,21 @@ enum EnvMapping : string {
   case Test = 'test';
   case Stage = 'stage';
   case Prod = 'prod';
+
+  /**
+   * Gets the translated label for given environment.
+   *
+   * @return \Drupal\Core\StringTranslation\TranslatableMarkup
+   *   The translated label.
+   */
+  public function label() : TranslatableMarkup {
+    return match ($this) {
+      self::Local => new TranslatableMarkup('Local'),
+      self::Dev => new TranslatableMarkup('Development'),
+      self::Test => new TranslatableMarkup('Testing'),
+      self::Stage => new TranslatableMarkup('Staging'),
+      self::Prod => new TranslatableMarkup('Production'),
+    };
+  }
 
 }

--- a/src/Environment/Environment.php
+++ b/src/Environment/Environment.php
@@ -20,7 +20,7 @@ final class Environment {
    *   The protocol.
    * @param string $id
    *   Environment resolver identifier for the project.
-   * @param string $environmentName
+   * @param \Drupal\helfi_api_base\Environment\EnvMapping $environment
    *   The environment name.
    */
   public function __construct(
@@ -28,7 +28,7 @@ final class Environment {
     private array $paths,
     private string $protocol,
     private string $id,
-    private string $environmentName
+    private EnvMapping $environment
   ) {
   }
 
@@ -146,7 +146,17 @@ final class Environment {
    *   The environment.
    */
   public function getEnvironmentName(): string {
-    return $this->environmentName;
+    return $this->environment->name;
+  }
+
+  /**
+   * Gets the environment mapping.
+   *
+   * @return \Drupal\helfi_api_base\Environment\EnvMapping
+   *   The environment mapping.
+   */
+  public function getEnvironment() : EnvMapping {
+    return $this->environment;
   }
 
 }

--- a/src/Environment/Environment.php
+++ b/src/Environment/Environment.php
@@ -146,7 +146,7 @@ final class Environment {
    *   The environment.
    */
   public function getEnvironmentName(): string {
-    return $this->environment->name;
+    return $this->environment->value;
   }
 
   /**

--- a/src/Environment/Environment.php
+++ b/src/Environment/Environment.php
@@ -20,15 +20,15 @@ final class Environment {
    *   The protocol.
    * @param string $id
    *   Environment resolver identifier for the project.
-   * @param \Drupal\helfi_api_base\Environment\EnvMapping $environment
+   * @param \Drupal\helfi_api_base\Environment\EnvironmentEnum $environment
    *   The environment name.
    */
   public function __construct(
-    private string $domain,
-    private array $paths,
-    private string $protocol,
-    private string $id,
-    private EnvMapping $environment
+    private readonly string $domain,
+    private readonly array $paths,
+    private readonly string $protocol,
+    private readonly string $id,
+    private readonly EnvironmentEnum $environment
   ) {
   }
 
@@ -152,10 +152,10 @@ final class Environment {
   /**
    * Gets the environment mapping.
    *
-   * @return \Drupal\helfi_api_base\Environment\EnvMapping
+   * @return \Drupal\helfi_api_base\Environment\EnvironmentEnum
    *   The environment mapping.
    */
-  public function getEnvironment() : EnvMapping {
+  public function getEnvironment() : EnvironmentEnum {
     return $this->environment;
   }
 

--- a/src/Environment/EnvironmentEnum.php
+++ b/src/Environment/EnvironmentEnum.php
@@ -12,7 +12,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 /**
  * Enum to contains all available environments.
  */
-enum EnvMapping : string {
+enum EnvironmentEnum : string {
 
   case Local = 'local';
   case Dev = 'dev';

--- a/src/Environment/EnvironmentResolver.php
+++ b/src/Environment/EnvironmentResolver.php
@@ -65,8 +65,8 @@ final class EnvironmentResolver implements EnvironmentResolverInterface {
       throw new \InvalidArgumentException('Failed to parse projects.');
     }
 
-    foreach ($projects as $name => $item) {
-      $project = new Project();
+    foreach ($projects as $id => $item) {
+      $project = new Project($id);
 
       foreach ($item as $environment => $settings) {
         if (!isset($settings['domain'], $settings['path'])) {
@@ -76,11 +76,11 @@ final class EnvironmentResolver implements EnvironmentResolverInterface {
           $settings['domain'],
           $settings['path'],
           $settings['protocol'] ?? 'https',
-          $name,
-          EnvMapping::tryFrom($environment),
+          $id,
+          EnvironmentEnum::tryFrom($environment),
         ));
       }
-      $this->projects[$name] = $project;
+      $this->projects[$id] = $project;
     }
   }
 

--- a/src/Environment/EnvironmentResolver.php
+++ b/src/Environment/EnvironmentResolver.php
@@ -77,7 +77,7 @@ final class EnvironmentResolver implements EnvironmentResolverInterface {
           $settings['path'],
           $settings['protocol'] ?? 'https',
           $name,
-          $environment
+          EnvMapping::tryFrom($environment),
         ));
       }
       $this->projects[$name] = $project;

--- a/src/Environment/EnvironmentResolverInterface.php
+++ b/src/Environment/EnvironmentResolverInterface.php
@@ -12,7 +12,7 @@ interface EnvironmentResolverInterface {
   /**
    * Gets all projects.
    *
-   * @return array
+   * @return \Drupal\helfi_api_base\Environment\Project[]
    *   The projects.
    */
   public function getProjects() : array;

--- a/src/Environment/Project.php
+++ b/src/Environment/Project.php
@@ -4,10 +4,11 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_api_base\Environment;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Webmozart\Assert\Assert;
 
 /**
- * A value object to store all projects.
+ * A value object of a project.
  */
 final class Project {
 
@@ -33,12 +34,37 @@ final class Project {
   /**
    * Constructs a new instance.
    *
+   * @param string $name
+   *   The project name.
    * @param \Drupal\helfi_api_base\Environment\Environment[] $environments
    *   The environments.
    */
-  public function __construct(array $environments = []) {
+  public function __construct(
+    private readonly string $name,
+    array $environments = []
+  ) {
     Assert::allIsInstanceOf($environments, Environment::class);
     $this->environments = $environments;
+  }
+
+  /**
+   * Gets the project label.
+   *
+   * @return \Drupal\Core\StringTranslation\TranslatableMarkup
+   *   The label.
+   */
+  public function label() : TranslatableMarkup {
+    return match ($this->name) {
+      self::ASUMINEN => new TranslatableMarkup('Housing'),
+      self::ETUSIVU => new TranslatableMarkup('Frontpage'),
+      self::KASVATUS_KOULUTUS => new TranslatableMarkup('Childhood and education'),
+      self::KUVA => new TranslatableMarkup('Culture and leisure'),
+      self::LIIKENNE => new TranslatableMarkup('Urban environment and traffic'),
+      self::REKRY => new TranslatableMarkup('Open jobs'),
+      self::STRATEGIA => new TranslatableMarkup('Decision-making'),
+      self::TERVEYS => new TranslatableMarkup('Health and social services'),
+      self::TYO_YRITTAMINEN => new TranslatableMarkup('Business and work'),
+    };
   }
 
   /**

--- a/src/Environment/Project.php
+++ b/src/Environment/Project.php
@@ -68,6 +68,21 @@ final class Project {
   }
 
   /**
+   * Checks if environment exists.
+   *
+   * @param string $environment
+   *   The environment key.
+   *
+   * @return bool
+   *   TRUE if environment exists.
+   */
+  public function hasEnvironment(string $environment) : bool {
+    $environment = $this->normalizeEnvironmentName($environment);
+
+    return isset($this->environments[$environment]);
+  }
+
+  /**
    * Gets the given environment.
    *
    * @param string $environment
@@ -79,7 +94,7 @@ final class Project {
   public function getEnvironment(string $environment) : Environment {
     $environment = $this->normalizeEnvironmentName($environment);
 
-    if (!isset($this->environments[$environment])) {
+    if (!$this->hasEnvironment($environment)) {
       throw new \InvalidArgumentException(sprintf('Environment "%s" not found.', $environment));
     }
     return $this->environments[$environment];

--- a/src/EventSubscriber/DeployHookEventSubscriberBase.php
+++ b/src/EventSubscriber/DeployHookEventSubscriberBase.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Defines a base class for deploy hooks.
+ */
+abstract class DeployHookEventSubscriberBase implements EventSubscriberInterface {
+
+  /**
+   * Responds to 'helfi_api_base.post_deploy' event.
+   *
+   * @param \Symfony\Contracts\EventDispatcher\Event $event
+   *   The event.
+   */
+  public function onPostDeploy(Event $event) : void {
+  }
+
+  /**
+   * Responds to 'helfi_api_base.pre_deploy' event.
+   *
+   * @param \Symfony\Contracts\EventDispatcher\Event $event
+   *   The event.
+   */
+  public function onPreDeploy(Event $event) : void {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() : array {
+    return [
+      'helfi_api_base.post_deploy' => ['onPostDeploy'],
+      'helfi_api_base.pre_deploy' => ['onPreDeploy'],
+    ];
+  }
+
+}

--- a/src/EventSubscriber/EnsureApiAccountsSubscriber.php
+++ b/src/EventSubscriber/EnsureApiAccountsSubscriber.php
@@ -36,7 +36,11 @@ final class EnsureApiAccountsSubscriber extends DeployHookEventSubscriberBase {
    * {@inheritdoc}
    *
    * This is used to ensure that API accounts always retain the same
-   * credentials.
+   * credentials, i.e. it creates any missing accounts and then force
+   * resets the password.
+   *
+   * The event is triggered by 'drush helfi:post-deploy'
+   * command as part of deployment tasks.
    */
   public function onPostDeploy(Event $event) : void {
     $accounts = $this->configFactory

--- a/src/EventSubscriber/EnsureApiAccountsSubscriber.php
+++ b/src/EventSubscriber/EnsureApiAccountsSubscriber.php
@@ -79,6 +79,7 @@ final class EnsureApiAccountsSubscriber extends DeployHookEventSubscriberBase {
         $user->addRole($role);
       }
       $user->setPassword($password)
+        ->activate()
         ->save();
     }
   }

--- a/src/EventSubscriber/EnsureApiAccountsSubscriber.php
+++ b/src/EventSubscriber/EnsureApiAccountsSubscriber.php
@@ -55,9 +55,13 @@ final class EnsureApiAccountsSubscriber extends DeployHookEventSubscriberBase {
         $account['roles'] = [];
       }
 
+      if (!isset($account['mail'])) {
+        $account['mail'] = 'drupal+' . $account['username'] . '@hel.fi';
+      }
       [
         'username' => $username,
         'password' => $password,
+        'mail' => $mail,
         'roles' => $roles,
       ] = $account;
 
@@ -79,6 +83,7 @@ final class EnsureApiAccountsSubscriber extends DeployHookEventSubscriberBase {
         $user->addRole($role);
       }
       $user->setPassword($password)
+        ->setEmail($mail)
         ->activate()
         ->save();
     }

--- a/src/EventSubscriber/EnsureApiAccountsSubscriber.php
+++ b/src/EventSubscriber/EnsureApiAccountsSubscriber.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\EventSubscriber;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Handles post deploy tasks.
+ */
+final class EnsureApiAccountsSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
+   */
+  public function __construct(
+    private EntityTypeManagerInterface $entityTypeManager,
+    private MessengerInterface $messenger,
+  ) {
+  }
+
+  /**
+   * Responds to 'helfi_api_base.post_deploy' event.
+   *
+   * This is used to ensure that API accounts always retain the same
+   * credentials.
+   *
+   * @param \Symfony\Contracts\EventDispatcher\Event $event
+   *   The event.
+   */
+  public function onPostDeploy(Event $event) : void {
+    $accounts = [];
+
+    foreach (getenv() as $key => $value) {
+      // Scan for ENV variables starting with DRUPAL_ and ending with _API_KEY.
+      // For example 'DRUPAL_NAVIGATION_API_KEY'.
+      if (!str_starts_with($key, 'DRUPAL_') || !str_ends_with($key, '_API_KEY')) {
+        continue;
+      }
+      $accounts[$key] = $value;
+    }
+
+    /** @var \Drupal\user\UserStorageInterface $storage */
+    $storage = $this->entityTypeManager->getStorage('user');
+
+    foreach ($accounts as $env => $value) {
+      [$username, $password] = explode(':', base64_decode($value));
+
+      $this->messenger
+        ->addMessage(
+          sprintf('[helfi_api_base]: %s found. Resetting password...', $env)
+        );
+      /** @var \Drupal\user\UserInterface $user */
+      if (!$user = user_load_by_name($username)) {
+        $this->messenger
+          ->addMessage(
+            sprintf('[helfi_api_base]: Account %s not found. Creating a new account.', $username)
+          );
+        $user = $storage->create([
+          'name' => $username,
+        ]);
+      }
+      $user->setPassword($password)
+        ->save();
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() : array {
+    return [
+      'helfi_api_base.post_deploy' => ['onPostDeploy'],
+    ];
+  }
+
+}

--- a/src/EventSubscriber/EnsureApiAccountsSubscriber.php
+++ b/src/EventSubscriber/EnsureApiAccountsSubscriber.php
@@ -46,7 +46,7 @@ final class EnsureApiAccountsSubscriber extends DeployHookEventSubscriberBase {
     /** @var \Drupal\user\UserStorageInterface $storage */
     $storage = $this->entityTypeManager->getStorage('user');
 
-    foreach ($accounts as $account) {
+    foreach ($accounts ?? [] as $account) {
       if (!isset($account['roles'])) {
         $account['roles'] = [];
       }
@@ -57,10 +57,6 @@ final class EnsureApiAccountsSubscriber extends DeployHookEventSubscriberBase {
         'roles' => $roles,
       ] = $account;
 
-      $this->messenger
-        ->addMessage(
-          sprintf('[helfi_api_base]: %s found. Resetting password.', $username)
-        );
       /** @var \Drupal\user\UserInterface $user */
       if (!$user = user_load_by_name($username)) {
         $this->messenger

--- a/src/Plugin/DebugDataItem/Composer.php
+++ b/src/Plugin/DebugDataItem/Composer.php
@@ -87,7 +87,6 @@ class Composer extends DebugDataItemPluginBase implements ContainerFactoryPlugin
       $data['packages'][] = [
         'name' => $package->getName(),
         'source' => $package->getSource(),
-
         'version' => $package->getVersion(),
         'time' => $package->getTime()?->format('c'),
       ];

--- a/src/Plugin/DebugDataItem/MaintenanceMode.php
+++ b/src/Plugin/DebugDataItem/MaintenanceMode.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\Plugin\DebugDataItem;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\helfi_api_base\DebugDataItemPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Plugin implementation of the debug_data_item.
+ *
+ * @DebugDataItem(
+ *   id = "maintenance_mode",
+ *   label = @Translation("Maintenance mode"),
+ *   description = @Translation("Maintenance mode")
+ * )
+ */
+class MaintenanceMode extends DebugDataItemPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The state service.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  private StateInterface $state;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = new static($configuration, $plugin_id, $plugin_definition);
+    $instance->state = $container->get('state');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function collect(): array {
+    return ['maintenance_mode' => $this->state->get('system.maintenance_mode')];
+  }
+
+}

--- a/src/Plugin/rest/resource/DebugDataResource.php
+++ b/src/Plugin/rest/resource/DebugDataResource.php
@@ -99,7 +99,7 @@ final class DebugDataResource extends ResourceBase implements DependentPluginInt
   /**
    * {@inheritdoc}
    */
-  public function calculateDependencies() {
+  public function calculateDependencies() : array {
     $dependencies = [
       'module' => ['user'],
     ];

--- a/src/Plugin/rest/resource/PackageVersion.php
+++ b/src/Plugin/rest/resource/PackageVersion.php
@@ -89,7 +89,7 @@ final class PackageVersion extends ResourceBase implements DependentPluginInterf
   /**
    * {@inheritdoc}
    */
-  public function calculateDependencies() {
+  public function calculateDependencies() : array {
     return [
       'module' => ['user'],
     ];

--- a/tests/src/Functional/InstallTest.php
+++ b/tests/src/Functional/InstallTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_api_base\Functional;
+
+use Drupal\Core\Config\Schema\SchemaIncompleteException;
+use Drupal\Tests\BrowserTestBase as CoreBrowserTestBase;
+use Drupal\user\Entity\Role;
+
+/**
+ * Tests helfi_api_base install hooks.
+ *
+ * @group helfi_api_base
+ */
+class InstallTest extends CoreBrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() : void {
+    parent::setUp();
+
+    try {
+      // We override 'api_accounts' config in platform's settings.php and the
+      // 'helfi_api_base' module is not installed at this point, so the
+      // schema does not exist yet and will fail. Catch the exception to
+      // simulate the normal installation process.
+      $this->config('helfi_api_base.api_accounts')
+        ->set('accounts', [
+          [
+            'username' => 'helfi-admin',
+            'password' => '123',
+            'roles' => ['debug_api'],
+          ],
+        ])
+        ->save();
+    }
+    catch (SchemaIncompleteException) {
+    }
+  }
+
+  /**
+   * Make sure debug api role is created when accounts are defined.
+   */
+  public function testInstall() : void {
+    // Enable the 'helfi_api_base' module to trigger hook_modules_installed().
+    $this->container->get('module_installer')->install(['helfi_api_base']);
+    // Make sure debug api role is created when we have api accounts with
+    // 'debug_api' roles.
+    $this->assertFalse(Role::load('debug_api')->hasPermission('restful get helfi_debug_data'));
+
+    // Make sure required 'rest' permissions are granted when the 'rest' module
+    // is enabled.
+    $this->container->get('module_installer')->install(['rest']);
+    $this->assertTrue(Role::load('debug_api')->hasPermission('restful get helfi_debug_data'));
+  }
+
+}

--- a/tests/src/Kernel/EnsureApiAccountsSubscriberTest.php
+++ b/tests/src/Kernel/EnsureApiAccountsSubscriberTest.php
@@ -81,6 +81,7 @@ class EnsureApiAccountsSubscriberTest extends KernelTestBase {
       ->save();
     $service->onPostDeploy(new Event());
     $account = user_load_by_name('helfi-admin');
+    $this->assertEquals('drupal+helfi-admin@hel.fi', $account->getEmail());
     $this->assertTrue($account->hasRole('test'));
     $this->assertFalse($account->isBlocked());
     $this->assertTrue($account->hasRole('test2'));

--- a/tests/src/Kernel/EnsureApiAccountsSubscriberTest.php
+++ b/tests/src/Kernel/EnsureApiAccountsSubscriberTest.php
@@ -82,6 +82,7 @@ class EnsureApiAccountsSubscriberTest extends KernelTestBase {
     $service->onPostDeploy(new Event());
     $account = user_load_by_name('helfi-admin');
     $this->assertTrue($account->hasRole('test'));
+    $this->assertFalse($account->isBlocked());
     $this->assertTrue($account->hasRole('test2'));
     $this->assertTrue($passwordHasher->check('666', $account->getPassword()));
   }

--- a/tests/src/Kernel/EnsureApiAccountsSubscriberTest.php
+++ b/tests/src/Kernel/EnsureApiAccountsSubscriberTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_api_base\Kernel\Plugin\DebugDataItem;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Tests EnsureApiAccountSubscriber.
+ *
+ * @group helfi_api_base
+ */
+class EnsureApiAccountsSubscriberTest extends KernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'helfi_api_base',
+    'user',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() : void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+  }
+
+  /**
+   * Tests that existing API account's password is reset.
+   *
+   * @covers \Drupal\helfi_api_base\EventSubscriber\EnsureApiAccountsSubscriber::getSubscribedEvents
+   * @covers \Drupal\helfi_api_base\EventSubscriber\EnsureApiAccountsSubscriber::onPostDeploy
+   * @covers \Drupal\helfi_api_base\EventSubscriber\EnsureApiAccountsSubscriber::__construct
+   */
+  public function testPasswordReset(): void {
+    $passwordHasher = $this->container->get('password');
+    $this->assertFalse(user_load_by_name('helfi-admin'));
+    // Make sure account is created if one does not exist yet.
+    putenv('DRUPAL_NAVIGATION_API_KEY=' . base64_encode('helfi-admin:123'));
+    /** @var \Drupal\helfi_api_base\EventSubscriber\EnsureApiAccountsSubscriber $service */
+    $service = $this->container->get('helfi_api_base.ensure_api_accounts_subscriber');
+    $service->onPostDeploy(new Event());
+
+    /** @var \Drupal\Core\Password\PhpassHashedPassword $passwordHasher */
+    $this->assertTrue($passwordHasher->check('123', user_load_by_name('helfi-admin')->getPassword()));
+
+    // Make sure we can change the password.
+    putenv('DRUPAL_NAVIGATION_API_KEY=' . base64_encode('helfi-admin:666'));
+    $service->onPostDeploy(new Event());
+    /** @var \Drupal\Core\Password\PhpassHashedPassword $passwordHasher */
+    $this->assertTrue($passwordHasher->check('666', user_load_by_name('helfi-admin')->getPassword()));
+  }
+
+}

--- a/tests/src/Kernel/Plugin/DebugDataItem/MaintenanceModeTest.php
+++ b/tests/src/Kernel/Plugin/DebugDataItem/MaintenanceModeTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_api_base\Kernel\Plugin\DebugDataItem;
+
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests Maintenance mode debug data plugin.
+ *
+ * @group helfi_api_base
+ */
+class MaintenanceModeTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'helfi_api_base',
+  ];
+
+  /**
+   * Tests that composer plugin collects data properly.
+   *
+   * @covers \Drupal\helfi_api_base\Plugin\DebugDataItem\MaintenanceMode::collect
+   * @covers \Drupal\helfi_api_base\Plugin\DebugDataItem\MaintenanceMode::create
+   */
+  public function testCompile() : void {
+    /** @var \Drupal\helfi_api_base\DebugDataItemPluginManager $manager */
+    $manager = $this->container->get('plugin.manager.debug_data_item');
+    /** @var \Drupal\helfi_api_base\Plugin\DebugDataItem\MaintenanceMode $plugin */
+    $plugin = $manager->createInstance('maintenance_mode');
+    \Drupal::state()->set('system.maintenance_mode', TRUE);
+    $this->assertEquals(['maintenance_mode' => TRUE], $plugin->collect());
+
+    \Drupal::state()->set('system.maintenance_mode', FALSE);
+    $this->assertEquals(['maintenance_mode' => FALSE], $plugin->collect());
+  }
+
+}

--- a/tests/src/Unit/EnvironmentResolverTest.php
+++ b/tests/src/Unit/EnvironmentResolverTest.php
@@ -65,6 +65,7 @@ class EnvironmentResolverTest extends UnitTestCase {
    * @covers \Drupal\helfi_api_base\Environment\Environment::getDomain
    * @covers \Drupal\helfi_api_base\Environment\Project::__construct
    * @covers \Drupal\helfi_api_base\Environment\Project::getEnvironment
+   * @covers \Drupal\helfi_api_base\Environment\Project::hasEnvironment
    * @covers \Drupal\helfi_api_base\Environment\Project::addEnvironment
    * @covers \Drupal\helfi_api_base\Environment\EnvironmentTrait::normalizeEnvironmentName
    */
@@ -84,6 +85,7 @@ class EnvironmentResolverTest extends UnitTestCase {
    * @covers \Drupal\helfi_api_base\Environment\Environment::getDomain
    * @covers \Drupal\helfi_api_base\Environment\Project::__construct
    * @covers \Drupal\helfi_api_base\Environment\Project::getEnvironment
+   * @covers \Drupal\helfi_api_base\Environment\Project::hasEnvironment
    * @covers \Drupal\helfi_api_base\Environment\Project::addEnvironment
    * @covers \Drupal\helfi_api_base\Environment\EnvironmentTrait::normalizeEnvironmentName
    */
@@ -144,6 +146,7 @@ class EnvironmentResolverTest extends UnitTestCase {
    * @covers \Drupal\helfi_api_base\Environment\Environment::doGetUrl
    * @covers \Drupal\helfi_api_base\Environment\Project::__construct
    * @covers \Drupal\helfi_api_base\Environment\Project::getEnvironment
+   * @covers \Drupal\helfi_api_base\Environment\Project::hasEnvironment
    * @covers \Drupal\helfi_api_base\Environment\Project::addEnvironment
    * @covers \Drupal\helfi_api_base\Environment\EnvironmentTrait::normalizeEnvironmentName
    * @dataProvider resolvePathExceptionData
@@ -190,6 +193,7 @@ class EnvironmentResolverTest extends UnitTestCase {
    * @covers \Drupal\helfi_api_base\Environment\Environment::getEnvironmentName
    * @covers \Drupal\helfi_api_base\Environment\Project::__construct
    * @covers \Drupal\helfi_api_base\Environment\Project::getEnvironment
+   * @covers \Drupal\helfi_api_base\Environment\Project::hasEnvironment
    * @covers \Drupal\helfi_api_base\Environment\Project::addEnvironment
    * @covers \Drupal\helfi_api_base\Environment\EnvironmentTrait::normalizeEnvironmentName
    * @dataProvider environmentMapData
@@ -229,6 +233,7 @@ class EnvironmentResolverTest extends UnitTestCase {
    * @covers \Drupal\helfi_api_base\Environment\Environment::getInternalAddress
    * @covers \Drupal\helfi_api_base\Environment\Project::__construct
    * @covers \Drupal\helfi_api_base\Environment\Project::getEnvironment
+   * @covers \Drupal\helfi_api_base\Environment\Project::hasEnvironment
    * @covers \Drupal\helfi_api_base\Environment\Project::addEnvironment
    * @covers \Drupal\helfi_api_base\Environment\EnvironmentTrait::normalizeEnvironmentName
    * @dataProvider validUrlData
@@ -380,6 +385,7 @@ class EnvironmentResolverTest extends UnitTestCase {
    * @covers \Drupal\helfi_api_base\Environment\Project::__construct
    * @covers \Drupal\helfi_api_base\Environment\Project::addEnvironment
    * @covers \Drupal\helfi_api_base\Environment\Project::getEnvironment
+   * @covers \Drupal\helfi_api_base\Environment\Project::hasEnvironment
    * @covers \Drupal\helfi_api_base\Environment\EnvironmentTrait::normalizeEnvironmentName
    */
   public function testGetActiveEnvironment() : void {


### PR DESCRIPTION
## What was done
- [UHF-6316](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6316)
- [UHF-8059](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8059)

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X-list-of-envs`
* Add this to your `local.settings.php`: 
```
$config['helfi_api_base.api_accounts']['accounts'] = [
  ['username' => 'helfi-debug-data', 'password' => '123', 'roles' => ['debug_api']],
];
```
* Run `drush cr` and `drush updb`
* Run `drush helfi:post-deploy`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that `Debug API` role is created and granted with `restful get helfi_debug_data` permission
* [x] Check that `helfi-debug-data` account is created and granted with `debug_api` role
* [x] Check that `basic_auth` module is enabled after update hooks


[UHF-6316]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-6316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[UHF-6316]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-6316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[UHF-8059]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Other PRs
- https://github.com/City-of-Helsinki/drupal-helfi-platform/pull/122