### PR TITLE
kasvatus-koulutus to kasvatus-ja-koulutus

### DIFF
--- a/fixtures/environments.json
+++ b/fixtures/environments.json
@@ -109,7 +109,7 @@
     "environments": {
       "local": {
         "path": {
-          "fi": "/fi/kasvatus-koulutus",
+          "fi": "/fi/kasvatus-ja-koulutus",
           "sv": "/sv/fostran-och-utbildning",
           "en": "/en/childhood-and-education"
         },
@@ -119,7 +119,7 @@
       },
       "test": {
         "path": {
-          "fi": "/fi/test-kasvatus-koulutus",
+          "fi": "/fi/test-kasvatus-ja-koulutus",
           "sv": "/sv/test-fostran-och-utbildning",
           "en": "/en/test-childhood-and-education"
         },
@@ -130,7 +130,7 @@
       },
       "stage": {
         "path": {
-          "fi": "/fi/staging-kasvatus-koulutus",
+          "fi": "/fi/staging-kasvatus-ja-koulutus",
           "sv": "/sv/staging-fostran-och-utbildning",
           "en": "/en/staging-childhood-and-education"
         },
@@ -141,7 +141,7 @@
       },
       "prod": {
         "path": {
-          "fi": "/fi/kasvatus-koulutus",
+          "fi": "/fi/kasvatus-ja-koulutus",
           "sv": "/sv/fostran-och-utbildning",
           "en": "/en/childhood-and-education"
         },


### PR DESCRIPTION
Fix wrong proxy route for kasko. It messed up kasko mobile js menu.

You can reproduce the problem by opening Kasko-site, set it on mobile size and open the mobile menu. You should get JS error on browser console and the url should have `#menu` on it. This indicates that fallback menu is used instead of js menu. You can reproduce this currently on testing and production.

How to test:

[Setup global navigation as described here KASKO being the other site](https://github.com/City-of-Helsinki/drupal-module-helfi-navigation/blob/main/README.md#local-development) 

After kasko has been set up and global navigation works
- Set site on mobile size
- Click the mobile hamburger menu
- Check the site url: it should not have `#menu` in it (`#menu` in site url means that fallback menu is used instead of js menu)
