### PR TITLE
UHF-8525: Service to invalidate cache tags from external instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Base module for `drupal-helfi-platform` ecosystem.
 ## Features
 
 - [API user manager](documentation/api-accounts.md): Allows API users to be created/managed from an environment variable.
+- [Automatic external cache invalidation](documentation/automatic-external-cache-invalidation.md): Invalidate caches from external projects
 - [Debug collector](documentation/debug.md): A plugin to collect and show various debug information in one place.
 - [Deploy hooks](documentation/deploy-hooks.md): Allows custom tasks to be defined that are run before or after deployment.
 - [Environment resolver](documentation/environment-resolver.md): A service to fetch metadata for given project.
@@ -19,6 +20,7 @@ Base module for `drupal-helfi-platform` ecosystem.
 - [Link text filter](documentation/link.md): A custom `filter` plugin to scan and parse external links
 - [Migrate](documentation/migrate.md): Various features to help with migrations.
 - [PO Importer](documentation/po-importer.md): Allows modules to define translations that can be imported using Drush.
+- [PubSub messaging](documentation/pubsub-messaging.md): A PubSub message service to send/receive messages.
 - [Remote Entity](documentation/remote-entity.md): A base entity to be used with migrations.
 - [Testing](documentation/testing.md): Various features to help with automated testing.
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Base module for `drupal-helfi-platform` ecosystem.
 
 ## Requirements
 
-- PHP 8.0 or higher
+- PHP 8.1 or higher
 
 ## Features
 
 - [API user manager](documentation/api-accounts.md): Allows API users to be created/managed from an environment variable.
-- [Automatic external cache invalidation](documentation/automatic-external-cache-invalidation.md): Invalidate caches from external projects
+- [Automatic external cache invalidation](documentation/automatic-external-cache-invalidation.md): Invalidate caches from external projects using [PubSub messaging](documentation/pubsub-messaging.md) service.
 - [Debug collector](documentation/debug.md): A plugin to collect and show various debug information in one place.
 - [Deploy hooks](documentation/deploy-hooks.md): Allows custom tasks to be defined that are run before or after deployment.
 - [Environment resolver](documentation/environment-resolver.md): A service to fetch metadata for given project.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "/__w/drupal-module-helfi-api-base/drupal-module-helfi-api-base::"

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,13 @@
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
     "require": {
-        "php": "^8.1",
         "drupal/entity": "^1.0",
         "drupal/filelog": "^2.1",
         "drupal/health_check": "^3.0",
-        "t4web/composer-lock-parser": "^1.0"
+        "firebase/php-jwt": "^6.5",
+        "php": "^8.1",
+        "t4web/composer-lock-parser": "^1.0",
+        "textalk/websocket": "^1.6"
     },
     "conflict": {
         "drupal/helfi_debug": "*"

--- a/config/schema/helfi_api_base.schema.yml
+++ b/config/schema/helfi_api_base.schema.yml
@@ -30,6 +30,18 @@ helfi_api_base.api_accounts:
             sequence:
               type: string
 
+helfi_api_base.pubsub.settings:
+  type: config_object
+  mapping:
+    endpoint:
+      type: string
+    access_token:
+      type: string
+    hub:
+      type: string
+    group:
+      type: string
+
 helfi_api_base.environment_resolver.settings:
   type: config_entity
   mapping:

--- a/documentation/automatic-external-cache-invalidation.md
+++ b/documentation/automatic-external-cache-invalidation.md
@@ -1,0 +1,63 @@
+# Automatic external cache invalidation
+
+Provides a way to invalidate arbitrary cache tags across all instances.
+
+See [PubSub messaging](/documentation/pubsub-messaging.md) for documentation about underlying architecture and required settings.
+
+For example, this can be used to invalidate:
+- [News list paragraph blocks](https://github.com/City-of-Helsinki/drupal-helfi-platform-config) when News content is modified on Etusivu instance
+- [Global navigation menu blocks](https://github.com/City-of-Helsinki/drupal-module-helfi-navigation/) when navigation is modified
+- [Global announcement blocks](https://github.com/City-of-Helsinki/drupal-helfi-platform-config) when Etusivu modifies announcement content
+
+## Usage
+
+Use `helfi_api_base.cache_tag_invalidator` to invalidate arbitrary cache tags in all instances.
+
+```php
+/** @var \Drupal\helfi_api_base\Cache\CacheTagInvalidator $service */
+$service = \Drupal::service('helfi_api_base.cache_tag_invalidator');
+$service->invalidateTags(['an array of cache tags']);
+```
+
+This can be run automatically every time a CRUD operation is performed on certain entity. For example:
+
+```php
+/**
+ * Invalidate external caches.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The entity to flush cache tags for.
+ */
+function helfi_etusivu_invalidate_external_caches(EntityInterface $entity) : void {
+  // Only flush caches when we're saving announcement node.
+  $isAnnouncementNode = $entity->getEntityTypeId() === 'node' && $entity->bundle() === 'announcement';
+
+  if (!$isAnnouncementNode) {
+    return;
+  }
+  /** @var \Drupal\helfi_api_base\Cache\CacheTagInvalidator $service */
+  $service = \Drupal::service('helfi_api_base.cache_tag_invalidator');
+  $service->invalidateTags(['helfi_external_entity_announcement']);
+}
+
+/**
+ * Implements hook_entity_update().
+ */
+function helfi_etusivu_entity_update(EntityInterface $entity) : void {
+  helfi_etusivu_invalidate_external_caches($entity);
+}
+
+/**
+ * Implements hook_entity_delete().
+ */
+function helfi_etusivu_entity_delete(EntityInterface $entity) : void {
+  helfi_etusivu_invalidate_external_caches($entity);
+}
+
+/**
+ * Implements hook_entity_insert().
+ */
+function helfi_etusivu_entity_insert(EntityInterface $entity) : void {
+  helfi_etusivu_invalidate_external_caches($entity);
+}
+```

--- a/documentation/pubsub-messaging.md
+++ b/documentation/pubsub-messaging.md
@@ -1,0 +1,88 @@
+# PubSub messaging
+
+Provides an integration to [Azure's Web PubSub service](https://azure.microsoft.com/en-us/products/web-pubsub) to deliver real-time messages between instances.
+
+## Configuration
+
+You must define the following settings to use this feature:
+
+```php
+$config['helfi_api_base.pubsub.settings']['access_token'] = '<access-token>';
+$config['helfi_api_base.pubsub.settings']['endpoint'] = '<url to azure pubsub endpoint>';
+// Hub and group must be same in all instances that talk with each other.
+$config['helfi_api_base.pubsub.settings']['hub'] = '<hub>';
+$config['helfi_api_base.pubsub.settings']['group'] = '<group>';
+```
+
+## Usage
+
+### Sending a message
+
+Use `helfi_api_base.pubsub_manager` service to send real-time messages to other instances:
+
+```php
+/** @var \Drupal\helfi_api_base\Azure\PubSub\PubSubManagerInterface $service */
+$service = \Drupal::service('helfi_api_base.pubsub_manager')
+$data = ['random' => 'data'];
+$service->sendMessage($data);
+```
+
+The `$data` variable can contain anything that can be converted into a JSON string.
+
+### Listening to PubSub messages
+
+Use `drush helfi:azure:pubsub-listen` Drush command to listen to an incoming messages.
+
+The command is run until `\Drupal\helfi_api_base\Commands\PubSubCommands::MAX_MESSAGES` (500 by default) is reached and will exit with code 0 to prevent memory leaks.
+
+Alternatively, you can listen to incoming messages using `helfi_api_base.pubsub_manager` service:
+
+```php
+/** @var \Drupal\helfi_api_base\Azure\PubSub\PubSubManagerInterface $service */
+$service = \Drupal::service('helfi_api_base.pubsub_manager')
+$service->receive();
+```
+
+See [Responding to PubSub messages](#responding-to-pubsub-messages) to see how to respond to incoming messages.
+
+### Responding to PubSub messages
+
+Create an [event subscriber](https://www.drupal.org/docs/develop/creating-modules/subscribe-to-and-dispatch-events#s-drupal-8-events) that responds to `\Drupal\helfi_api_base\Azure\PubSub\Message` events:
+```php
+
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\yourmodule\EventSubscriber;
+
+use Drupal\helfi_api_base\Azure\PubSub\PubSubMessage;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class YourEventSubscriber implements EventSubscriberInterface {
+
+  public function onReceive(PubSubMessage $message) : void {
+    // Logic here.
+    // $message->data should contain the data passed to '::sendMessage()'.
+  }
+
+  public static function getSubscribedEvents() : array {
+    return [
+      PubSubMessage::class => ['onReceive'],
+    ];
+  }
+
+}
+```
+
+See [CacheTagInvalidatorSubscriber](/src/EventSubscriber/CacheTagInvalidatorSubscriber.php) for an example implementation.
+
+### Testing locally
+
+```php
+# public/sites/default/local.settings.php
+$config['helfi_api_base.pubsub.settings']['access_token'] = '<access-token>';
+$config['helfi_api_base.pubsub.settings']['endpoint'] = '<url to azure pubsub endpoint>';
+$config['helfi_api_base.pubsub.settings']['hub'] = '<hub>';
+$config['helfi_api_base.pubsub.settings']['group'] = '<group>';
+```

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -1,4 +1,10 @@
 services:
+  helfi_api_base.pubsub_commands:
+    class: \Drupal\helfi_api_base\Commands\PubSubCommands
+    arguments:
+      - '@helfi_api_base.pubsub_manager'
+    tags:
+      - { name: drush.command }
   helfi_api_base.api_account_commands:
     class: \Drupal\helfi_api_base\Commands\ApiAccountCommands
     arguments: ['@password_generator']

--- a/helfi_api_base.services.yml
+++ b/helfi_api_base.services.yml
@@ -98,7 +98,7 @@ services:
       - '@config.factory'
 
   helfi_api_base.pubsub_client_factory:
-    class: Drupal\helfi_api_base\PubSub\PubSubClientFactory
+    class: Drupal\helfi_api_base\Azure\PubSub\PubSubClientFactory
 
   helfi_api_base.pubsub_client:
     class: \WebSocket\Client

--- a/helfi_api_base.services.yml
+++ b/helfi_api_base.services.yml
@@ -91,3 +91,35 @@ services:
     class: Drupal\helfi_api_base\Vault\VaultManagerFactory
     arguments:
       - '@config.factory'
+
+  helfi_api_base.pubsub_settings_factory:
+    class: Drupal\helfi_api_base\Azure\PubSub\SettingsFactory
+    arguments:
+      - '@config.factory'
+
+  helfi_api_base.pubsub_client_factory:
+    class: Drupal\helfi_api_base\PubSub\PubSubClientFactory
+
+  helfi_api_base.pubsub_client:
+    class: \WebSocket\Client
+    factory: ['@helfi_api_base.pubsub_client_factory', 'create']
+    arguments:
+      - '@helfi_api_base.pubsub_settings'
+      - '@datetime.time'
+
+  helfi_api_base.pubsub_settings:
+    class: Drupal\helfi_api_base\Azure\PubSub\Settings
+    factory: ['@helfi_api_base.pubsub_settings_factory', 'create']
+
+  helfi_api_base.pubsub_manager:
+    class: Drupal\helfi_api_base\Azure\PubSub\PubSubManager
+    arguments:
+      - '@helfi_api_base.pubsub_client'
+      - '@event_dispatcher'
+      - '@datetime.time'
+      - '@helfi_api_base.pubsub_settings'
+
+  helfi_api_base.cache_invalidator_subscriber:
+    class: Drupal\helfi_api_base\EventSubscriber\CacheInvalidatorSubscriber
+    arguments:
+      - '@cache_tags.invalidator'

--- a/helfi_api_base.services.yml
+++ b/helfi_api_base.services.yml
@@ -119,7 +119,14 @@ services:
       - '@datetime.time'
       - '@helfi_api_base.pubsub_settings'
 
-  helfi_api_base.cache_invalidator_subscriber:
-    class: Drupal\helfi_api_base\EventSubscriber\CacheInvalidatorSubscriber
+  helfi_api_base.cache_tag_invalidator:
+    class: Drupal\helfi_api_base\Cache\CacheTagInvalidator
+    arguments:
+      - '@helfi_api_base.pubsub_manager'
+
+  helfi_api_base.cache_tag_invalidator_subscriber:
+    class: Drupal\helfi_api_base\EventSubscriber\CacheTagInvalidatorSubscriber
     arguments:
       - '@cache_tags.invalidator'
+    tags:
+      - { name: event_subscriber }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -43,8 +43,5 @@
     <directory suffix=".php">./src</directory>
     <file>./*.module</file>
   </include>
-  <exclude>
-    <directory suffix=".php">./src/Commands</directory>
-  </exclude>
 </coverage>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -43,5 +43,8 @@
     <directory suffix=".php">./src</directory>
     <file>./*.module</file>
   </include>
+  <exclude>
+    <directory suffix=".php">./src/Fixture</directory>
+  </exclude>
 </coverage>
 </phpunit>

--- a/src/Azure/PubSub/PubSubClientFactory.php
+++ b/src/Azure/PubSub/PubSubClientFactory.php
@@ -42,8 +42,6 @@ final class PubSubClientFactory {
         'Authorization' => 'Bearer ' . $authorizationToken,
         'Sec-WebSocket-Protocol' => 'json.webpubsub.azure.v1',
       ],
-      'timeout' => 120,
-      'persistent' => TRUE,
     ]);
   }
 

--- a/src/Azure/PubSub/PubSubClientFactory.php
+++ b/src/Azure/PubSub/PubSubClientFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\Azure\PubSub;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Firebase\JWT\JWT;
+use WebSocket\Client;
+
+/**
+ * A Web socket client factory.
+ */
+final class PubSubClientFactory {
+
+  /**
+   * Constructs a new websocket client object.
+   *
+   * @param \Drupal\helfi_api_base\Azure\PubSub\Settings $settings
+   *   The settings.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The time interface.
+   *
+   * @return \WebSocket\Client
+   *   The client.
+   */
+  public function create(Settings $settings, TimeInterface $time) : Client {
+    $url = sprintf('wss://%s/client/hubs/%s', rtrim($settings->endpoint, '/'), $settings->hub);
+
+    $authorizationToken = JWT::encode([
+      'aud' => $url,
+      'iat' => $time->getCurrentTime(),
+      'exp' => $time->getCurrentTime() + 3600,
+      'role' => [
+        'webpubsub.sendToGroup',
+        'webpubsub.joinLeaveGroup',
+      ],
+    ], $settings->accessToken, 'HS256');
+
+    return new Client($url, [
+      'headers' => [
+        'Authorization' => 'Bearer ' . $authorizationToken,
+        'Sec-WebSocket-Protocol' => 'json.webpubsub.azure.v1',
+      ],
+      'timeout' => 120,
+      'persistent' => TRUE,
+    ]);
+  }
+
+}

--- a/src/Azure/PubSub/PubSubManager.php
+++ b/src/Azure/PubSub/PubSubManager.php
@@ -108,6 +108,14 @@ final class PubSubManager implements PubSubManagerInterface {
   /**
    * {@inheritdoc}
    */
+  public function setTimeout(int $timeout) : self {
+    $this->client->setTimeout($timeout);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function sendMessage(array $message) : self {
     $this->joinGroup();
     $this->client

--- a/src/Azure/PubSub/PubSubManager.php
+++ b/src/Azure/PubSub/PubSubManager.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\Azure\PubSub;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use WebSocket\Client;
+
+/**
+ * A client to interact with Azure's PubSub service.
+ */
+final class PubSubManager implements PubSubManagerInterface {
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param \WebSocket\Client $client
+   *   The websocket client.
+   * @param \Symfony\Contracts\EventDispatcher\EventDispatcherInterface $eventDispatcher
+   *   The event dispatcher service.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The datetime service.
+   * @param \Drupal\helfi_api_base\Azure\PubSub\Settings $settings
+   *   The PubSub settings.
+   */
+  public function __construct(
+    private readonly Client $client,
+    private readonly EventDispatcherInterface $eventDispatcher,
+    private readonly TimeInterface $time,
+    private readonly Settings $settings,
+  ) {
+  }
+
+  /**
+   * Joins to a group.
+   *
+   * @return self
+   *   The self.
+   *
+   * @throws \JsonException
+   * @throws \WebSocket\ConnectionException
+   * @throws \WebSocket\TimeoutException
+   */
+  private function joinGroup() : self {
+    $this->client->text(
+      $this->encodeMessage([
+        'type' => 'joinGroup',
+        'group' => $this->settings->group,
+      ])
+    );
+    return $this;
+  }
+
+  /**
+   * Encodes the message.
+   *
+   * @param array $data
+   *   The data to encode.
+   *
+   * @return string
+   *   The encoded message.
+   *
+   * @throws \JsonException
+   */
+  private function encodeMessage(array $data) : string {
+    return json_encode($data, JSON_THROW_ON_ERROR);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function sendMessage(array $message) : self {
+    static $group = NULL;
+
+    // Join group only once per session.
+    if ($group === NULL) {
+      $group = $this->joinGroup();
+    }
+    $this->client
+      ->text(
+        $this->encodeMessage([
+          'type' => 'sendToGroup',
+          'group' => $this->settings->group,
+          'dataType' => 'json',
+          'data' => $message + [
+            'timestamp' => $this->time->getCurrentTime(),
+          ],
+        ])
+      );
+
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function receive() : string {
+    static $group = NULL;
+
+    // Join group only once per session.
+    if ($group === NULL) {
+      $group = $this->joinGroup();
+    }
+    $message = $this->client->receive();
+    $json = json_decode($message, TRUE, flags: JSON_THROW_ON_ERROR);
+
+    $this->eventDispatcher
+      ->dispatch(new PubSubMessage($json));
+    return $message;
+  }
+
+}

--- a/src/Azure/PubSub/PubSubManager.php
+++ b/src/Azure/PubSub/PubSubManager.php
@@ -114,10 +114,28 @@ final class PubSubManager implements PubSubManagerInterface {
   }
 
   /**
+   * Asserts the settings.
+   *
+   * This is used to exit early if required settings are not populated.
+   */
+  private function assertSettings() : self {
+    $vars = get_object_vars($this->settings);
+
+    foreach ($vars as $key => $value) {
+      if (empty($this->settings->{$key})) {
+        throw new ConnectionException("Azure PubSub '$key' is not configured.");
+      }
+    }
+    return $this;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function sendMessage(array $message) : self {
-    $this->joinGroup();
+    $this->assertSettings()
+      ->joinGroup();
+
     $this->client
       ->text(
         $this->encodeMessage([
@@ -137,7 +155,8 @@ final class PubSubManager implements PubSubManagerInterface {
    * {@inheritdoc}
    */
   public function receive() : string {
-    $this->joinGroup();
+    $this->assertSettings()
+      ->joinGroup();
     $message = $this->client->receive();
     $json = json_decode($message, TRUE, flags: JSON_THROW_ON_ERROR);
 

--- a/src/Azure/PubSub/PubSubManagerInterface.php
+++ b/src/Azure/PubSub/PubSubManagerInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\Azure\PubSub;
+
+/**
+ * A client to interact with Azure's PubSub service.
+ */
+interface PubSubManagerInterface {
+
+  /**
+   * Sends a message to a group.
+   *
+   * @param array $message
+   *   The message to send.
+   *
+   * @return $this
+   *   The self.
+   *
+   * @throws \JsonException
+   */
+  public function sendMessage(array $message): self;
+
+  /**
+   * Receive messages from given hub and group.
+   *
+   * @return string
+   *   The received message.
+   *
+   * @throws \JsonException
+   * @throws \WebSocket\ConnectionException
+   * @throws \WebSocket\TimeoutException
+   */
+  public function receive(): string;
+
+}

--- a/src/Azure/PubSub/PubSubManagerInterface.php
+++ b/src/Azure/PubSub/PubSubManagerInterface.php
@@ -19,6 +19,8 @@ interface PubSubManagerInterface {
    *   The self.
    *
    * @throws \JsonException
+   * @throws \WebSocket\ConnectionException
+   * @throws \WebSocket\TimeoutException
    */
   public function sendMessage(array $message): self;
 

--- a/src/Azure/PubSub/PubSubManagerInterface.php
+++ b/src/Azure/PubSub/PubSubManagerInterface.php
@@ -36,4 +36,15 @@ interface PubSubManagerInterface {
    */
   public function receive(): string;
 
+  /**
+   * Sets the client timeout.
+   *
+   * @param int $timeout
+   *   The timeout in seconds.
+   *
+   * @return self
+   *   The self.
+   */
+  public function setTimeout(int $timeout): self;
+
 }

--- a/src/Azure/PubSub/PubSubMessage.php
+++ b/src/Azure/PubSub/PubSubMessage.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\Azure\PubSub;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * A DTO to represent PubSub message event.
+ */
+final class PubSubMessage extends Event {
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param array $data
+   *   The arbitrary data.
+   */
+  public function __construct(
+    public readonly array $data,
+  ) {
+  }
+
+  /**
+   * Converts the object to json encoded string.
+   *
+   * @return string
+   *   The json encoded object.
+   */
+  public function __toString() : string {
+    return json_encode($this->data);
+  }
+
+}

--- a/src/Azure/PubSub/Settings.php
+++ b/src/Azure/PubSub/Settings.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\Azure\PubSub;
+
+/**
+ * A DTO representing PubSub settings.
+ */
+final class Settings {
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param string $hub
+   *   The hub.
+   * @param string $group
+   *   The group.
+   * @param string $endpoint
+   *   The API endpoint.
+   * @param string $accessToken
+   *   The API access token.
+   */
+  public function __construct(
+    public readonly string $hub,
+    public readonly string $group,
+    public readonly string $endpoint,
+    public readonly string $accessToken,
+  ) {
+  }
+
+}

--- a/src/Azure/PubSub/SettingsFactory.php
+++ b/src/Azure/PubSub/SettingsFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\Azure\PubSub;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+
+/**
+ * A factory to initialize Settings object.
+ */
+final class SettingsFactory {
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory service.
+   */
+  public function __construct(
+    private readonly ConfigFactoryInterface $configFactory
+  ) {
+  }
+
+  /**
+   * Constructs a new PubSub settings object.
+   *
+   * @return \Drupal\helfi_api_base\Azure\PubSub\Settings
+   *   The PubSub settings object.
+   */
+  public function create() : Settings {
+    $config = $this->configFactory->get('helfi_api_base.pubsub.settings');
+
+    return new Settings(
+      $config->get('hub') ?: '',
+      $config->get('group') ?: '',
+      $config->get('endpoint') ?: '',
+      $config->get('access_token') ?: '',
+    );
+  }
+
+}

--- a/src/Cache/CacheTagInvalidator.php
+++ b/src/Cache/CacheTagInvalidator.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Drupal\helfi_api_base\Cache;
 
 use Drupal\helfi_api_base\Azure\PubSub\PubSubManagerInterface;
+use WebSocket\ConnectionException;
 
 /**
  * A service to invalidate cache tags on all instances.
@@ -14,11 +15,11 @@ final class CacheTagInvalidator {
   /**
    * Constructs a new instance.
    *
-   * @param \Drupal\helfi_api_base\Azure\PubSub\PubSubManagerInterface $client
-   *   The client.
+   * @param \Drupal\helfi_api_base\Azure\PubSub\PubSubManagerInterface $pubSubManager
+   *   The PubSub manager.
    */
   public function __construct(
-    private readonly PubSubManagerInterface $client,
+    private readonly PubSubManagerInterface $pubSubManager,
   ) {
   }
 
@@ -32,9 +33,13 @@ final class CacheTagInvalidator {
    *   The self.
    */
   public function invalidateTags(array $tags) : self {
-    $this->client->sendMessage([
-      'tags' => $tags,
-    ]);
+    try {
+      $this->pubSubManager->sendMessage([
+        'tags' => $tags,
+      ]);
+    }
+    catch (ConnectionException) {
+    }
     return $this;
   }
 

--- a/src/Cache/CacheTagInvalidator.php
+++ b/src/Cache/CacheTagInvalidator.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\Cache;
+
+use Drupal\helfi_api_base\Azure\PubSub\PubSubManager;
+
+/**
+ * A service to invalidate cache tags on all instances.
+ */
+final class CacheTagInvalidator {
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param \Drupal\helfi_api_base\Azure\PubSub\PubSubManager $client
+   *   The client.
+   */
+  public function __construct(
+    private readonly PubSubManager $client,
+  ) {
+  }
+
+  /**
+   * Invalidates given cache tags.
+   *
+   * @param array $tags
+   *   An array of cache tags.
+   *
+   * @return $this
+   *   The self.
+   */
+  public function invalidateTags(array $tags) : self {
+    $this->client->sendMessage([
+      'tags' => $tags,
+    ]);
+    return $this;
+  }
+
+}

--- a/src/Cache/CacheTagInvalidator.php
+++ b/src/Cache/CacheTagInvalidator.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_api_base\Cache;
 
-use Drupal\helfi_api_base\Azure\PubSub\PubSubManager;
+use Drupal\helfi_api_base\Azure\PubSub\PubSubManagerInterface;
 
 /**
  * A service to invalidate cache tags on all instances.
@@ -14,11 +14,11 @@ final class CacheTagInvalidator {
   /**
    * Constructs a new instance.
    *
-   * @param \Drupal\helfi_api_base\Azure\PubSub\PubSubManager $client
+   * @param \Drupal\helfi_api_base\Azure\PubSub\PubSubManagerInterface $client
    *   The client.
    */
   public function __construct(
-    private readonly PubSubManager $client,
+    private readonly PubSubManagerInterface $client,
   ) {
   }
 

--- a/src/Commands/DeployCommands.php
+++ b/src/Commands/DeployCommands.php
@@ -6,8 +6,8 @@ namespace Drupal\helfi_api_base\Commands;
 
 use Drush\Attributes\Command;
 use Drush\Commands\DrushCommands;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * A drush command file.

--- a/src/Commands/PubSubCommands.php
+++ b/src/Commands/PubSubCommands.php
@@ -41,6 +41,8 @@ final class PubSubCommands extends DrushCommands {
    */
   #[Command(name: 'helfi:azure:pubsub-listen')]
   public function listen() : int {
+    $this->pubSubClient->setTimeout(120);
+
     for ($received = 0; $received < self::MAX_MESSAGES; $received++) {
       try {
         $message = $this->pubSubClient->receive();

--- a/src/Commands/PubSubCommands.php
+++ b/src/Commands/PubSubCommands.php
@@ -21,6 +21,7 @@ use WebSocket\TimeoutException;
 final class PubSubCommands extends DrushCommands {
 
   public const MAX_MESSAGES = 500;
+  public const CLIENT_TIMEOUT = 120;
 
   /**
    * Constructs a new instance.
@@ -41,7 +42,7 @@ final class PubSubCommands extends DrushCommands {
    */
   #[Command(name: 'helfi:azure:pubsub-listen')]
   public function listen() : int {
-    $this->pubSubClient->setTimeout(120);
+    $this->pubSubClient->setTimeout(self::CLIENT_TIMEOUT);
 
     for ($received = 0; $received < self::MAX_MESSAGES; $received++) {
       try {

--- a/src/Commands/PubSubCommands.php
+++ b/src/Commands/PubSubCommands.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_api_base\Commands;
+
+use Drupal\helfi_api_base\Azure\PubSub\PubSubManagerInterface;
+use Drush\Attributes\Command;
+use Drush\Commands\DrushCommands;
+use WebSocket\TimeoutException;
+
+/**
+ * A drush command to process PubSub events from Azure.
+ *
+ * Usage:
+ *
+ * $ drush helfi:azure-pubsub-listen
+ *    This will listen and process messages until the MAX_MESSAGES is
+ *    reached and then exits with code 0.
+ */
+final class PubSubCommands extends DrushCommands {
+
+  public const MAX_MESSAGES = 500;
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param \Drupal\helfi_api_base\Azure\PubSub\PubSubManagerInterface $pubSubClient
+   *   The PubSub client.
+   */
+  public function __construct(
+    private readonly PubSubManagerInterface $pubSubClient,
+  ) {
+  }
+
+  /**
+   * Listen to PubSub messages.
+   *
+   * @return int
+   *   The exit code.
+   */
+  #[Command(name: 'helfi:azure:pubsub-send')]
+  public function send() : int {
+    $this->pubSubClient->sendMessage([
+      'test' => 'test',
+    ]);
+    return DrushCommands::EXIT_SUCCESS;
+  }
+
+  /**
+   * Listen to PubSub messages.
+   *
+   * @return int
+   *   The exit code.
+   */
+  #[Command(name: 'helfi:azure:pubsub-listen')]
+  public function listen() : int {
+    for ($received = 0; $received < self::MAX_MESSAGES; $received++) {
+      try {
+        $message = $this->pubSubClient->receive();
+        $this->io()
+          ->writeln(sprintf('Received message [#%d]: %s', $received, $message));
+      }
+      catch (TimeoutException) {
+      }
+      catch (\JsonException $e) {
+        $this->io()->writeln('Invalid json: ' . $e->getMessage());
+      }
+    }
+    $this->io()
+      ->writeln(sprintf('Received maximum number of messages (%s). Exiting...', self::MAX_MESSAGES));
+
+    return DrushCommands::EXIT_SUCCESS;
+  }
+
+}

--- a/src/Commands/PubSubCommands.php
+++ b/src/Commands/PubSubCommands.php
@@ -39,20 +39,6 @@ final class PubSubCommands extends DrushCommands {
    * @return int
    *   The exit code.
    */
-  #[Command(name: 'helfi:azure:pubsub-send')]
-  public function send() : int {
-    $this->pubSubClient->sendMessage([
-      'test' => 'test',
-    ]);
-    return DrushCommands::EXIT_SUCCESS;
-  }
-
-  /**
-   * Listen to PubSub messages.
-   *
-   * @return int
-   *   The exit code.
-   */
   #[Command(name: 'helfi:azure:pubsub-listen')]
   public function listen() : int {
     for ($received = 0; $received < self::MAX_MESSAGES; $received++) {

--- a/src/EventSubscriber/CacheInvalidatorSubscriber.php
+++ b/src/EventSubscriber/CacheInvalidatorSubscriber.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\EventSubscriber;
+
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\helfi_api_base\Azure\PubSub\PubSubMessage;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * A cache invalidator subscriber.
+ */
+final class CacheInvalidatorSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param \Drupal\Core\Cache\CacheTagsInvalidatorInterface $cacheTagsInvalidator
+   *   The cache tag invalidator subscriber.
+   */
+  public function __construct(
+    private readonly CacheTagsInvalidatorInterface $cacheTagsInvalidator,
+  ) {
+  }
+
+  /**
+   * Responds to PubSub message events.
+   *
+   * @param \Drupal\helfi_api_base\Azure\PubSub\PubSubMessage $message
+   *   The event to respond to.
+   */
+  public function onReceive(PubSubMessage $message) : void {
+    if (!isset($message->data['tags'])) {
+      return;
+    }
+    $this->cacheTagsInvalidator->invalidateTags($message->data['tags']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() : array {
+    return [
+      PubSubMessage::class => ['onReceive'],
+    ];
+  }
+
+}

--- a/src/EventSubscriber/CacheTagInvalidatorSubscriber.php
+++ b/src/EventSubscriber/CacheTagInvalidatorSubscriber.php
@@ -11,7 +11,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 /**
  * A cache invalidator subscriber.
  */
-final class CacheInvalidatorSubscriber implements EventSubscriberInterface {
+final class CacheTagInvalidatorSubscriber implements EventSubscriberInterface {
 
   /**
    * Constructs a new instance.

--- a/src/EventSubscriber/CacheTagInvalidatorSubscriber.php
+++ b/src/EventSubscriber/CacheTagInvalidatorSubscriber.php
@@ -49,7 +49,7 @@ final class CacheTagInvalidatorSubscriber implements EventSubscriberInterface {
     if (!method_exists($this->cacheTagsInvalidator, 'resetChecksums')) {
       throw new \LogicException('CacheTagsInvalidatorInterface::resetCheckSums() does not exist anymore.');
     }
-    $this->cacheTagsInvalidator->resetCheckSums();
+    $this->cacheTagsInvalidator->resetChecksums();
   }
 
   /**

--- a/src/EventSubscriber/CacheTagInvalidatorSubscriber.php
+++ b/src/EventSubscriber/CacheTagInvalidatorSubscriber.php
@@ -31,10 +31,10 @@ final class CacheTagInvalidatorSubscriber implements EventSubscriberInterface {
    *   The event to respond to.
    */
   public function onReceive(PubSubMessage $message) : void {
-    if (!isset($message->data['tags'])) {
+    if (!isset($message->data['data']['tags'])) {
       return;
     }
-    $this->cacheTagsInvalidator->invalidateTags($message->data['tags']);
+    $this->cacheTagsInvalidator->invalidateTags($message->data['data']['tags']);
   }
 
   /**

--- a/src/Language/DefaultLanguageResolver.php
+++ b/src/Language/DefaultLanguageResolver.php
@@ -12,24 +12,20 @@ use Drupal\Core\Language\LanguageManagerInterface;
 final class DefaultLanguageResolver {
 
   /**
-   * The language manager.
-   *
-   * @var \Drupal\Core\Language\LanguageManagerInterface
-   */
-  protected LanguageManagerInterface $languageManager;
-
-  /**
    * Constructs a new instance.
    *
    * @param array $defaultLanguages
    *   Default languages.
    * @param string $fallbackLanguage
    *   Fallback language.
-   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   * @param \Drupal\Core\Language\LanguageManagerInterface $languageManager
    *   Language manager.
    */
-  public function __construct(private array $defaultLanguages, private string $fallbackLanguage, LanguageManagerInterface $language_manager) {
-    $this->languageManager = $language_manager;
+  public function __construct(
+    private readonly array $defaultLanguages,
+    private readonly string $fallbackLanguage,
+    private readonly LanguageManagerInterface $languageManager
+  ) {
   }
 
   /**

--- a/src/Plugin/migrate/process/EntityChanged.php
+++ b/src/Plugin/migrate/process/EntityChanged.php
@@ -50,7 +50,13 @@ final class EntityChanged extends ProcessPluginBase implements ContainerFactoryP
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition, MigrationInterface $migration = NULL) : self {
+  public static function create(
+    ContainerInterface $container,
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    MigrationInterface $migration = NULL
+  ) : self {
     $instance = new self($configuration, $plugin_id, $plugin_definition);
     $instance->entityTypeManager = $container->get('entity_type.manager');
 

--- a/tests/src/Kernel/Cache/CacheTagInvalidatorTest.php
+++ b/tests/src/Kernel/Cache/CacheTagInvalidatorTest.php
@@ -45,7 +45,10 @@ class CacheTagInvalidatorTest extends KernelTestBase {
 
     $client = $this->prophesize(Client::class);
     $client->text(Argument::any());
-    $client->receive()->willReturn('{"data": {"tags":["node:123"]}}');
+    $client->receive()->willReturn(
+      '{"type":"event","event":"connected"}',
+      '{"data": {"tags":["node:123"]}}'
+    );
     $pubSubManager = new PubSubManager(
       $client->reveal(),
       $this->container->get('event_dispatcher'),

--- a/tests/src/Kernel/Cache/CacheTagInvalidatorTest.php
+++ b/tests/src/Kernel/Cache/CacheTagInvalidatorTest.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\helfi_api_base\Kernel\Cache;
 
-use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
 use Drupal\helfi_api_base\Azure\PubSub\PubSubManager;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\helfi_api_base\Traits\CacheTagInvalidatorTrait;

--- a/tests/src/Kernel/Cache/CacheTagInvalidatorTest.php
+++ b/tests/src/Kernel/Cache/CacheTagInvalidatorTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\helfi_api_base\Kernel\Cache;
 use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
 use Drupal\helfi_api_base\Azure\PubSub\PubSubManager;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\helfi_api_base\Traits\CacheTagInvalidatorTrait;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use WebSocket\Client;
@@ -20,6 +21,7 @@ use WebSocket\Client;
 class CacheTagInvalidatorTest extends KernelTestBase {
 
   use ProphecyTrait;
+  use CacheTagInvalidatorTrait;
 
   /**
    * {@inheritdoc}
@@ -53,9 +55,8 @@ class CacheTagInvalidatorTest extends KernelTestBase {
     // the event subscriber is actually run and the invalidation logic is
     // actually triggered.
     // @see \Drupal\helfi_api_base\EventSubscriber\CacheTagInvalidatorSubscriber
-    $cacheTagInvalidator = $this->prophesize(CacheTagsInvalidatorInterface::class);
-    $cacheTagInvalidator->invalidateTags(['node:123'])->shouldBeCalledTimes(1);
-    $this->container->set('cache_tags.invalidator', $cacheTagInvalidator->reveal());
+    $cacheTagInvalidator = $this->mockCacheInvalidator();
+    $this->container->set('cache_tags.invalidator', $cacheTagInvalidator);
 
     $client = $this->prophesize(Client::class);
     $client->text(Argument::any());
@@ -75,6 +76,7 @@ class CacheTagInvalidatorTest extends KernelTestBase {
     /** @var \Drupal\helfi_api_base\Cache\CacheTagInvalidator $sut */
     $sut = $this->container->get('helfi_api_base.cache_tag_invalidator');
     $sut->invalidateTags(['node:123']);
+    $this->assertArrayHasKey('node:123', $cacheTagInvalidator->tags);
   }
 
 }

--- a/tests/src/Kernel/Cache/CacheTagInvalidatorTest.php
+++ b/tests/src/Kernel/Cache/CacheTagInvalidatorTest.php
@@ -45,7 +45,7 @@ class CacheTagInvalidatorTest extends KernelTestBase {
 
     $client = $this->prophesize(Client::class);
     $client->text(Argument::any());
-    $client->receive()->willReturn('{"tags":["node:123"]}');
+    $client->receive()->willReturn('{"data": {"tags":["node:123"]}}');
     $pubSubManager = new PubSubManager(
       $client->reveal(),
       $this->container->get('event_dispatcher'),

--- a/tests/src/Kernel/Cache/CacheTagInvalidatorTest.php
+++ b/tests/src/Kernel/Cache/CacheTagInvalidatorTest.php
@@ -29,6 +29,20 @@ class CacheTagInvalidatorTest extends KernelTestBase {
   ];
 
   /**
+   * {@inheritdoc}
+   */
+  protected function setUp() : void {
+    parent::setUp();
+
+    $this->config('helfi_api_base.pubsub.settings')
+      ->set('endpoint', 'wss://localhost')
+      ->set('hub', 'hub')
+      ->set('group', 'group')
+      ->set('access_token', '123')
+      ->save();
+  }
+
+  /**
    * @covers ::__construct
    * @covers ::invalidateTags
    * @covers \Drupal\helfi_api_base\EventSubscriber\CacheTagInvalidatorSubscriber::onReceive

--- a/tests/src/Kernel/Cache/CacheTagInvalidatorTest.php
+++ b/tests/src/Kernel/Cache/CacheTagInvalidatorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_api_base\Kernel\Cache;
+
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\helfi_api_base\Azure\PubSub\PubSubManager;
+use Drupal\KernelTests\KernelTestBase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use WebSocket\Client;
+
+/**
+ * Tests Cache invalidator subscriber.
+ *
+ * @coversDefaultClass \Drupal\helfi_api_base\Cache\CacheTagInvalidator
+ * @group helfi_api_base
+ */
+class CacheTagInvalidatorTest extends KernelTestBase {
+
+  use ProphecyTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'helfi_api_base',
+  ];
+
+  /**
+   * @covers ::__construct
+   * @covers ::invalidateTags
+   * @covers \Drupal\helfi_api_base\EventSubscriber\CacheTagInvalidatorSubscriber::onReceive
+   * @covers \Drupal\helfi_api_base\EventSubscriber\CacheTagInvalidatorSubscriber::getSubscribedEvents
+   */
+  public function testInvalidateTags() : void {
+    // Override the cache_tags.invalidator service, so we can verify that
+    // the event subscriber is actually run and the invalidation logic is
+    // actually triggered.
+    // @see \Drupal\helfi_api_base\EventSubscriber\CacheTagInvalidatorSubscriber
+    $cacheTagInvalidator = $this->prophesize(CacheTagsInvalidatorInterface::class);
+    $cacheTagInvalidator->invalidateTags(['node:123'])->shouldBeCalledTimes(1);
+    $this->container->set('cache_tags.invalidator', $cacheTagInvalidator->reveal());
+
+    $client = $this->prophesize(Client::class);
+    $client->text(Argument::any());
+    $client->receive()->willReturn('{"tags":["node:123"]}');
+    $pubSubManager = new PubSubManager(
+      $client->reveal(),
+      $this->container->get('event_dispatcher'),
+      $this->container->get('datetime.time'),
+      $this->container->get('helfi_api_base.pubsub_settings'),
+    );
+    $this->container->set('helfi_api_base.pubsub_manager', $pubSubManager);
+    $pubSubManager->receive();
+
+    /** @var \Drupal\helfi_api_base\Cache\CacheTagInvalidator $sut */
+    $sut = $this->container->get('helfi_api_base.cache_tag_invalidator');
+    $sut->invalidateTags(['node:123']);
+  }
+
+}

--- a/tests/src/Kernel/EventSubscriber/EnsureApiAccountsSubscriberTest.php
+++ b/tests/src/Kernel/EventSubscriber/EnsureApiAccountsSubscriberTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types = 1);
 
-namespace Drupal\Tests\helfi_api_base\Kernel;
+namespace Drupal\Tests\helfi_api_base\Kernel\EventSubscriber;
 
 use Drupal\helfi_api_base\Environment\EnvironmentEnum;
 use Drupal\helfi_api_base\Environment\Project;

--- a/tests/src/Kernel/Language/DefaultLanguageResolverTest.php
+++ b/tests/src/Kernel/Language/DefaultLanguageResolverTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_api_base\Kernel\Language;
+
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * @coversDefaultClass \Drupal\helfi_api_base\Language\DefaultLanguageResolver
+ * @group helfi_api_base
+ */
+class DefaultLanguageResolverTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'helfi_api_base',
+  ];
+
+  /**
+   * @covers ::__construct
+   * @covers ::getDefaultLanguages
+   * @covers ::getFallbackLanguage
+   */
+  public function testContainerParameters() : void {
+    $defaultLanguages = $this->container->getParameter('helfi_api_base.default_languages');
+    $fallbackLanguage = $this->container->getParameter('helfi_api_base.fallback_language');
+    /** @var \Drupal\helfi_api_base\Language\DefaultLanguageResolver $sut */
+    $sut = $this->container->get('helfi_api_base.default_language_resolver');
+
+    $this->assertEquals($defaultLanguages, $sut->getDefaultLanguages());
+    $this->assertEquals($fallbackLanguage, $sut->getFallbackLanguage());
+  }
+
+}

--- a/tests/src/Kernel/Plugin/migrate/process/EntityChangedTest.php
+++ b/tests/src/Kernel/Plugin/migrate/process/EntityChangedTest.php
@@ -14,6 +14,7 @@ use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\migrate\Row;
 use Drupal\remote_entity_test\Entity\RemoteEntityTest;
 use Drupal\Tests\helfi_api_base\Kernel\ApiKernelTestBase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Tests the entity_changed plugin.
@@ -24,6 +25,7 @@ use Drupal\Tests\helfi_api_base\Kernel\ApiKernelTestBase;
 class EntityChangedTest extends ApiKernelTestBase {
 
   use MigrateTrait;
+  use ProphecyTrait;
 
   /**
    * {@inheritdoc}
@@ -107,7 +109,7 @@ class EntityChangedTest extends ApiKernelTestBase {
    * @return array[]
    *   The data.
    */
-  public function entityNotChangedData() {
+  public function entityNotChangedData() : array {
     return [
       [1, '2020-10-29T10:05:05', '2020-10-29T10:05:05'],
       [2, '2020-10-29T09:05:05', '2020-10-28T10:05:05'],
@@ -142,6 +144,8 @@ class EntityChangedTest extends ApiKernelTestBase {
 
   /**
    * Tests entity when it has changed.
+   *
+   * @covers ::transform
    */
   public function testEntityHasChanged() : void {
     $this->assertTransform(1, '2020-10-28T10:00:01', '2020-10-30T12:00:00');

--- a/tests/src/Kernel/Plugin/migrate/process/EntityChangedTest.php
+++ b/tests/src/Kernel/Plugin/migrate/process/EntityChangedTest.php
@@ -119,6 +119,7 @@ class EntityChangedTest extends ApiKernelTestBase {
    * Tests entity when it has not changed.
    *
    * @covers ::transform
+   * @covers ::create
    * @dataProvider entityNotChangedData
    */
   public function testEntityNotChanged(int $id, string $date1, string $date2): void {
@@ -132,6 +133,7 @@ class EntityChangedTest extends ApiKernelTestBase {
    * Tests entity when it has not changed.
    *
    * @covers ::transform
+   * @covers ::create
    * @dataProvider entityNotChangedData
    */
   public function testEntityNotChangedNotPartialMigrate(int $id, string $date1, string $date2): void {
@@ -145,6 +147,7 @@ class EntityChangedTest extends ApiKernelTestBase {
    * Tests entity when it has changed.
    *
    * @covers ::transform
+   * @covers ::create
    */
   public function testEntityHasChanged() : void {
     $this->assertTransform(1, '2020-10-28T10:00:01', '2020-10-30T12:00:00');

--- a/tests/src/Kernel/Plugin/migrate/process/EntityChangedTest.php
+++ b/tests/src/Kernel/Plugin/migrate/process/EntityChangedTest.php
@@ -68,8 +68,7 @@ class EntityChangedTest extends ApiKernelTestBase {
     $configuration = [
       'entity_type' => 'remote_entity_test',
     ];
-    return \Drupal::service('plugin.manager.migrate.process')
-      ->createInstance('entity_has_changed', $configuration, $migration);
+    return EntityChanged::create($this->container, $configuration, 'entity_has_changed', [], $migration);
   }
 
   /**

--- a/tests/src/Traits/CacheTagInvalidatorTrait.php
+++ b/tests/src/Traits/CacheTagInvalidatorTrait.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_api_base\Traits;
+
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+
+/**
+ * Provides a trait to mock cache invalidator service.
+ */
+trait CacheTagInvalidatorTrait {
+
+  /**
+   * Mock core's CacheTagsInvalidator class.
+   *
+   * The CacheTagsInvalidatorInterface does not define 'resetChecksums()'
+   * method and since the default CacheTagsInvalidator class is marked
+   * as final we cannot mock it.
+   *
+   * @return \Drupal\Core\Cache\CacheTagsInvalidatorInterface
+   *   The cache invalidator class.
+   */
+  protected function mockCacheInvalidator() : CacheTagsInvalidatorInterface {
+    return new class () implements CacheTagsInvalidatorInterface {
+
+      /**
+       * A list of invalidated tags.
+       *
+       * @var array
+       */
+      public array $tags = [];
+
+      /**
+       * The number of times resetChecksums has been called.
+       *
+       * @var int
+       */
+      public int $checkSumResets = 0;
+
+      /**
+       * {@inheritdoc}
+       */
+      public function invalidateTags(array $tags) : void {
+        foreach ($tags as $tag) {
+          $this->tags[$tag] = $tag;
+        }
+      }
+
+      /**
+       * Add missing resetChecksums() method.
+       *
+       * @see \Drupal\Core\Cache\CacheTagsInvalidator::resetChecksums()
+       */
+      public function resetChecksums() : void {
+        $this->checkSumResets++;
+      }
+
+    };
+  }
+
+}

--- a/tests/src/Unit/Azure/PubSub/PubSubClientFactoryTest.php
+++ b/tests/src/Unit/Azure/PubSub/PubSubClientFactoryTest.php
@@ -20,7 +20,6 @@ class PubSubClientFactoryTest extends UnitTestCase {
   use ProphecyTrait;
 
   /**
-   * @covers ::__construct
    * @covers ::create
    */
   public function testConstruct() : void {

--- a/tests/src/Unit/Azure/PubSub/PubSubClientFactoryTest.php
+++ b/tests/src/Unit/Azure/PubSub/PubSubClientFactoryTest.php
@@ -21,6 +21,7 @@ class PubSubClientFactoryTest extends UnitTestCase {
 
   /**
    * @covers ::create
+   * @covers \Drupal\helfi_api_base\Azure\PubSub\Settings::__construct
    */
   public function testConstruct() : void {
     $settings = new Settings(

--- a/tests/src/Unit/Azure/PubSub/PubSubClientFactoryTest.php
+++ b/tests/src/Unit/Azure/PubSub/PubSubClientFactoryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_api_base\Unit\Azure\PubSub;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\helfi_api_base\Azure\PubSub\PubSubClientFactory;
+use Drupal\helfi_api_base\Azure\PubSub\Settings;
+use Drupal\Tests\UnitTestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use WebSocket\Client;
+
+/**
+ * @coversDefaultClass \Drupal\helfi_api_base\Azure\PubSub\PubSubClientFactory
+ * @group helfi_api_base
+ */
+class PubSubClientFactoryTest extends UnitTestCase {
+
+  use ProphecyTrait;
+
+  /**
+   * @covers ::__construct
+   * @covers ::create
+   */
+  public function testConstruct() : void {
+    $settings = new Settings(
+      'hub',
+      'group',
+      'endpoint',
+      'accessToken',
+    );
+    $sut = new PubSubClientFactory();
+    $client = $sut->create($settings, $this->prophesize(TimeInterface::class)->reveal());
+    $this->assertInstanceOf(Client::class, $client);
+  }
+
+}

--- a/tests/src/Unit/Azure/PubSub/PubSubManagerTest.php
+++ b/tests/src/Unit/Azure/PubSub/PubSubManagerTest.php
@@ -23,6 +23,26 @@ class PubSubManagerTest extends UnitTestCase {
   use ProphecyTrait;
 
   /**
+   * @covers ::setTimeout
+   */
+  public function testSetTimeout() : void {
+    $client = $this->prophesize(Client::class);
+    $client->setTimeout(5)->shouldBeCalled();
+    $sut = new PubSubManager(
+      $client->reveal(),
+      $this->prophesize(EventDispatcherInterface::class)->reveal(),
+      $this->prophesize(TimeInterface::class)->reveal(),
+      new Settings(
+        'hub',
+        'local',
+        'localhost',
+        'token',
+      )
+    );
+    $sut->setTimeout(5);
+  }
+
+  /**
    * @covers ::sendMessage
    * @covers ::joinGroup
    * @covers ::encodeMessage

--- a/tests/src/Unit/Azure/PubSub/PubSubManagerTest.php
+++ b/tests/src/Unit/Azure/PubSub/PubSubManagerTest.php
@@ -26,7 +26,8 @@ class PubSubManagerTest extends UnitTestCase {
    * @covers ::__construct
    * @covers ::assertSettings
    * @covers ::receive
-   * @cover ::sendMessage
+   * @covers ::sendMessage
+   * @covers \Drupal\helfi_api_base\Azure\PubSub\Settings::__construct
    * @dataProvider assertSettingsExceptionData
    */
   public function testAssertSettingsException(string $method, array $args) : void {

--- a/tests/src/Unit/Azure/PubSub/PubSubManagerTest.php
+++ b/tests/src/Unit/Azure/PubSub/PubSubManagerTest.php
@@ -25,6 +25,8 @@ class PubSubManagerTest extends UnitTestCase {
    * @covers ::sendMessage
    * @covers ::joinGroup
    * @covers ::encodeMessage
+   * @covers ::__construct
+   * @covers \Drupal\helfi_api_base\Azure\PubSub\Settings::__construct
    */
   public function testSendMessage() : void {
     $time = $this->prophesize(TimeInterface::class);
@@ -53,6 +55,10 @@ class PubSubManagerTest extends UnitTestCase {
   /**
    * @covers ::joinGroup
    * @covers ::receive
+   * @covers ::encodeMessage
+   * @covers ::__construct
+   * @covers \Drupal\helfi_api_base\Azure\PubSub\Settings::__construct
+   * @covers \Drupal\helfi_api_base\Azure\PubSub\PubSubMessage::__construct
    */
   public function testReceive() : void {
     $expectedMessage = '{"message":"test"}';

--- a/tests/src/Unit/Azure/PubSub/PubSubManagerTest.php
+++ b/tests/src/Unit/Azure/PubSub/PubSubManagerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_api_base\Unit\Azure\PubSub;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\helfi_api_base\Azure\PubSub\PubSubManager;
+use Drupal\helfi_api_base\Azure\PubSub\Settings;
+use Drupal\Tests\UnitTestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use WebSocket\Client;
+
+/**
+ * @coversDefaultClass \Drupal\helfi_api_base\Azure\PubSub\PubSubManager
+ * @group helfi_api_base
+ */
+class PubSubManagerTest extends UnitTestCase {
+
+  use ProphecyTrait;
+
+  /**
+   * @covers ::sendMessage
+   * @covers ::joinGroup
+   * @covers ::encodeMessage
+   */
+  public function testSendMessage() : void {
+    $time = $this->prophesize(TimeInterface::class);
+    $time->getCurrentTime()->willReturn(1234);
+
+    $client = $this->prophesize(Client::class);
+    $client->text('{"type":"joinGroup","group":"local"}')->shouldBeCalledTimes(1);
+    $client->text('{"type":"sendToGroup","group":"local","dataType":"json","data":{"test":"something","timestamp":1234}}')->shouldBeCalledTimes(2);
+
+    $sut = new PubSubManager(
+      $client->reveal(),
+      $this->prophesize(EventDispatcherInterface::class)->reveal(),
+      $time->reveal(),
+      new Settings(
+        'hub',
+        'local',
+        'localhost',
+        'token',
+      )
+    );
+    // Send two messages to test that we call ::joinGroup() once.
+    $sut->sendMessage(['test' => 'something']);
+    $sut->sendMessage(['test' => 'something']);
+  }
+
+  /**
+   * @covers ::joinGroup
+   * @covers ::receive
+   */
+  public function testReceive() : void {
+    $expectedMessage = '{"message":"test"}';
+    $dispatcher = $this->prophesize(EventDispatcherInterface::class);
+    $dispatcher->dispatch(Argument::any())->shouldBeCalledTimes(2);
+
+    $client = $this->prophesize(Client::class);
+    $client->text('{"type":"joinGroup","group":"local"}')->shouldBeCalledTimes(1);
+    $client->receive()->willReturn($expectedMessage);
+    $client->receive()->shouldBeCalledTimes(2);
+
+    $sut = new PubSubManager(
+      $client->reveal(),
+      $dispatcher->reveal(),
+      $this->prophesize(TimeInterface::class)->reveal(),
+      new Settings(
+        'hub',
+        'local',
+        'localhost',
+        'token',
+      )
+    );
+    // Call twice to make sure we call ::joinGroup() only once.
+    $this->assertEquals($expectedMessage, $sut->receive());
+    $this->assertEquals($expectedMessage, $sut->receive());
+  }
+
+}

--- a/tests/src/Unit/Azure/PubSub/PubSubManagerTest.php
+++ b/tests/src/Unit/Azure/PubSub/PubSubManagerTest.php
@@ -23,8 +23,46 @@ class PubSubManagerTest extends UnitTestCase {
   use ProphecyTrait;
 
   /**
+   * @covers ::__construct
+   * @covers ::assertSettings
+   * @covers ::receive
+   * @cover ::sendMessage
+   * @dataProvider assertSettingsExceptionData
+   */
+  public function testAssertSettingsException(string $method, array $args) : void {
+    $this->expectException(ConnectionException::class);
+    $this->expectExceptionMessage("Azure PubSub 'hub' is not configured");
+    $sut = new PubSubManager(
+      $this->prophesize(Client::class)->reveal(),
+      $this->prophesize(EventDispatcherInterface::class)->reveal(),
+      $this->prophesize(TimeInterface::class)->reveal(),
+      new Settings(
+        '',
+        'local',
+        'localhost',
+        'token',
+      )
+    );
+    call_user_func_array([$sut, $method], $args);
+  }
+
+  /**
+   * Data provider for testAssertSettingsException.
+   *
+   * @return array[]
+   *   The data.
+   */
+  public function assertSettingsExceptionData() : array {
+    return [
+      ['receive', []],
+      ['sendMessage', [['message' => 'message']]],
+    ];
+  }
+
+  /**
    * @covers ::setTimeout
    * @covers ::__construct
+   * @covers ::assertSettings
    * @covers \Drupal\helfi_api_base\Azure\PubSub\Settings::__construct
    */
   public function testSetTimeout() : void {
@@ -50,6 +88,7 @@ class PubSubManagerTest extends UnitTestCase {
    * @covers ::encodeMessage
    * @covers ::decodeMessage
    * @covers ::__construct
+   * @covers ::assertSettings
    * @covers \Drupal\helfi_api_base\Azure\PubSub\Settings::__construct
    */
   public function testJoinGroupException() : void {
@@ -83,6 +122,7 @@ class PubSubManagerTest extends UnitTestCase {
    * @covers ::encodeMessage
    * @covers ::decodeMessage
    * @covers ::__construct
+   * @covers ::assertSettings
    * @covers \Drupal\helfi_api_base\Azure\PubSub\Settings::__construct
    */
   public function testSendMessage() : void {
@@ -116,6 +156,7 @@ class PubSubManagerTest extends UnitTestCase {
    * @covers ::encodeMessage
    * @covers ::decodeMessage
    * @covers ::__construct
+   * @covers ::assertSettings
    * @covers \Drupal\helfi_api_base\Azure\PubSub\Settings::__construct
    * @covers \Drupal\helfi_api_base\Azure\PubSub\PubSubMessage::__construct
    */

--- a/tests/src/Unit/Azure/PubSub/PubSubManagerTest.php
+++ b/tests/src/Unit/Azure/PubSub/PubSubManagerTest.php
@@ -24,6 +24,8 @@ class PubSubManagerTest extends UnitTestCase {
 
   /**
    * @covers ::setTimeout
+   * @covers ::__construct
+   * @covers \Drupal\helfi_api_base\Azure\PubSub\Settings::__construct
    */
   public function testSetTimeout() : void {
     $client = $this->prophesize(Client::class);

--- a/tests/src/Unit/Azure/PubSub/PubSubMessageTest.php
+++ b/tests/src/Unit/Azure/PubSub/PubSubMessageTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_api_base\Unit\Azure\PubSub;
+
+use Drupal\helfi_api_base\Azure\PubSub\PubSubMessage;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\helfi_api_base\Azure\PubSub\PubSubMessage
+ * @group helfi_api_base
+ */
+class PubSubMessageTest extends UnitTestCase {
+
+  /**
+   * @covers ::__construct
+   * @covers ::__toString
+   */
+  public function testMessage() : void {
+    $data = ['test' => 'something'];
+    $sut = new PubSubMessage($data);
+    $this->assertSame($data, $sut->data);
+    $this->assertSame('{"test":"something"}', (string) $sut);
+  }
+
+}

--- a/tests/src/Unit/Azure/PubSub/SettingsTest.php
+++ b/tests/src/Unit/Azure/PubSub/SettingsTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_api_base\Unit\Azure\PubSub;
+
+use Drupal\helfi_api_base\Azure\PubSub\Settings;
+use Drupal\helfi_api_base\Azure\PubSub\SettingsFactory;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\helfi_api_base\Azure\PubSub\SettingsFactory
+ * @group helfi_api_base
+ */
+class SettingsTest extends UnitTestCase {
+
+  /**
+   * @covers \Drupal\helfi_api_base\Azure\PubSub\Settings::__construct
+   * @covers ::create
+   * @covers ::__construct
+   * @dataProvider settingsData
+   */
+  public function testSettings(array $values, array $expectedValues) : void {
+    $configFactory = $this->getConfigFactoryStub([
+      'helfi_api_base.pubsub.settings' => $values,
+    ]);
+    $sut = new SettingsFactory($configFactory);
+    $settings = $sut->create();
+    $this->assertInstanceOf(Settings::class, $settings);
+    $this->assertSame($settings->hub, $expectedValues['hub']);
+    $this->assertSame($settings->group, $expectedValues['group']);
+    $this->assertSame($settings->endpoint, $expectedValues['endpoint']);
+    $this->assertSame($settings->accessToken, $expectedValues['access_token']);
+  }
+
+  /**
+   * A data provider.
+   *
+   * @return array[]
+   *   The data.
+   */
+  public function settingsData() : array {
+    $values = [
+      [
+        [
+          'hub' => 'hub',
+          'group' => 'group',
+          'endpoint' => 'endpoint',
+          'access_token' => 'access_token',
+        ],
+        [
+          'hub' => 'hub',
+          'group' => 'group',
+          'endpoint' => 'endpoint',
+          'access_token' => 'access_token',
+        ],
+      ],
+    ];
+    // Make sure invalid values fallback to empty string.
+    foreach ([FALSE, NULL, ''] as $value) {
+      $values[] = [
+        [
+          'hub' => $value,
+          'group' => $value,
+          'endpoint' => $value,
+          'access_token' => $value,
+        ],
+        [
+          'hub' => '',
+          'group' => '',
+          'endpoint' => '',
+          'access_token' => '',
+        ],
+      ];
+    }
+    return $values;
+  }
+
+}

--- a/tests/src/Unit/Cache/CacheInvalidatorSubscriberTest.php
+++ b/tests/src/Unit/Cache/CacheInvalidatorSubscriberTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_api_base\Unit\Cache;
+
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\helfi_api_base\Azure\PubSub\PubSubMessage;
+use Drupal\helfi_api_base\EventSubscriber\CacheInvalidatorSubscriber;
+use Drupal\Tests\UnitTestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+/**
+ * @coversDefaultClass \Drupal\helfi_api_base\Cache\CacheTagInvalidator
+ * @group helfi_api_base
+ */
+class CacheInvalidatorSubscriberTest extends UnitTestCase {
+
+  use ProphecyTrait;
+
+  /**
+   * @covers ::__construct
+   * @covers ::invalidateTags
+   */
+  public function testInvalidCacheTags() : void {
+    $invalidator = $this->prophesize(CacheTagsInvalidatorInterface::class);
+    $invalidator->invalidateTags(Argument::any())->shouldNotBeCalled();
+    $sut = new CacheInvalidatorSubscriber($invalidator->reveal());
+    $sut->onReceive(new PubSubMessage([]));
+  }
+
+  /**
+   * @covers ::__construct
+   * @covers ::invalidateTags
+   */
+  public function testValidCacheTags() : void {
+    $invalidator = $this->prophesize(CacheTagsInvalidatorInterface::class);
+    $invalidator->invalidateTags(['node:123'])->shouldBeCalled();
+    $sut = new CacheInvalidatorSubscriber($invalidator->reveal());
+    $sut->onReceive(new PubSubMessage(['tags' => ['node:123']]));
+  }
+
+}

--- a/tests/src/Unit/Cache/CacheInvalidatorSubscriberTest.php
+++ b/tests/src/Unit/Cache/CacheInvalidatorSubscriberTest.php
@@ -4,9 +4,8 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\helfi_api_base\Unit\Cache;
 
-use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
-use Drupal\helfi_api_base\Azure\PubSub\PubSubMessage;
-use Drupal\helfi_api_base\EventSubscriber\CacheInvalidatorSubscriber;
+use Drupal\helfi_api_base\Azure\PubSub\PubSubManagerInterface;
+use Drupal\helfi_api_base\Cache\CacheTagInvalidator;
 use Drupal\Tests\UnitTestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -24,21 +23,11 @@ class CacheInvalidatorSubscriberTest extends UnitTestCase {
    * @covers ::invalidateTags
    */
   public function testInvalidCacheTags() : void {
-    $invalidator = $this->prophesize(CacheTagsInvalidatorInterface::class);
-    $invalidator->invalidateTags(Argument::any())->shouldNotBeCalled();
-    $sut = new CacheInvalidatorSubscriber($invalidator->reveal());
-    $sut->onReceive(new PubSubMessage([]));
-  }
+    $client = $this->prophesize(PubSubManagerInterface::class);
+    $client->sendMessage(Argument::any())->shouldBeCalledTimes(1);
 
-  /**
-   * @covers ::__construct
-   * @covers ::invalidateTags
-   */
-  public function testValidCacheTags() : void {
-    $invalidator = $this->prophesize(CacheTagsInvalidatorInterface::class);
-    $invalidator->invalidateTags(['node:123'])->shouldBeCalled();
-    $sut = new CacheInvalidatorSubscriber($invalidator->reveal());
-    $sut->onReceive(new PubSubMessage(['tags' => ['node:123']]));
+    $sut = new CacheTagInvalidator($client->reveal());
+    $sut->invalidateTags(['node:123']);
   }
 
 }

--- a/tests/src/Unit/Cache/CacheTagInvalidatorTEst.php
+++ b/tests/src/Unit/Cache/CacheTagInvalidatorTEst.php
@@ -9,23 +9,41 @@ use Drupal\helfi_api_base\Cache\CacheTagInvalidator;
 use Drupal\Tests\UnitTestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use WebSocket\ConnectionException;
 
 /**
  * @coversDefaultClass \Drupal\helfi_api_base\Cache\CacheTagInvalidator
  * @group helfi_api_base
  */
-class CacheInvalidatorSubscriberTest extends UnitTestCase {
+class CacheTagInvalidatorTEst extends UnitTestCase {
 
   use ProphecyTrait;
 
   /**
+   * Make sure PubSub message is sent when we invalidate cache tags.
+   *
    * @covers ::__construct
    * @covers ::invalidateTags
    */
-  public function testInvalidCacheTags() : void {
+  public function testCacheTags() : void {
     $client = $this->prophesize(PubSubManagerInterface::class);
     $client->sendMessage(Argument::any())->shouldBeCalledTimes(1);
 
+    $sut = new CacheTagInvalidator($client->reveal());
+    $sut->invalidateTags(['node:123']);
+  }
+
+  /**
+   * Tests that ConnectionExceptions are caught.
+   *
+   * @covers ::__construct
+   * @covers ::invalidateTags
+   */
+  public function testConnectionException() : void {
+    $client = $this->prophesize(PubSubManagerInterface::class);
+    $client->sendMessage(Argument::any())
+      ->willThrow(ConnectionException::class)
+      ->shouldBeCalledTimes(1);
     $sut = new CacheTagInvalidator($client->reveal());
     $sut->invalidateTags(['node:123']);
   }

--- a/tests/src/Unit/Cache/CacheTagInvalidatorTest.php
+++ b/tests/src/Unit/Cache/CacheTagInvalidatorTest.php
@@ -15,7 +15,7 @@ use WebSocket\ConnectionException;
  * @coversDefaultClass \Drupal\helfi_api_base\Cache\CacheTagInvalidator
  * @group helfi_api_base
  */
-class CacheTagInvalidatorTEst extends UnitTestCase {
+class CacheTagInvalidatorTest extends UnitTestCase {
 
   use ProphecyTrait;
 

--- a/tests/src/Unit/Commands/DeployCommandsTest.php
+++ b/tests/src/Unit/Commands/DeployCommandsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_api_base\Unit\Commands;
+
+use Drupal\helfi_api_base\Commands\DeployCommands;
+use Drupal\Tests\UnitTestCase;
+use Drush\Commands\DrushCommands;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @coversDefaultClass \Drupal\helfi_api_base\Commands\DeployCommands
+ * @group helfi_api_base
+ */
+class DeployCommandsTest extends UnitTestCase {
+
+  use ProphecyTrait;
+
+  /**
+   * @covers ::__construct
+   * @covers ::postDeploy
+   */
+  public function testPostDeploy() : void {
+    $eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
+    $eventDispatcher->dispatch(new Event(), 'helfi_api_base.post_deploy')->shouldBeCalledTimes(1);
+    $sut = new DeployCommands($eventDispatcher->reveal());
+    $this->assertEquals(DrushCommands::EXIT_SUCCESS, $sut->postDeploy());
+  }
+
+  /**
+   * @covers ::__construct
+   * @covers ::preDeploy
+   */
+  public function testPreDeploy() : void {
+    $eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
+    $eventDispatcher->dispatch(new Event(), 'helfi_api_base.pre_deploy')->shouldBeCalledTimes(1);
+    $sut = new DeployCommands($eventDispatcher->reveal());
+    $this->assertEquals(DrushCommands::EXIT_SUCCESS, $sut->preDeploy());
+  }
+
+}

--- a/tests/src/Unit/Commands/PubSubCommandsTest.php
+++ b/tests/src/Unit/Commands/PubSubCommandsTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_api_base\Unit\Commands;
+
+use Drupal\helfi_api_base\Azure\PubSub\PubSubManagerInterface;
+use Drupal\helfi_api_base\Commands\PubSubCommands;
+use Drupal\Tests\UnitTestCase;
+use Drush\Commands\DrushCommands;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use WebSocket\ConnectionException;
+use WebSocket\TimeoutException;
+
+/**
+ * @coversDefaultClass \Drupal\helfi_api_base\Commands\PubSubCommands
+ * @group helfi_api_base
+ */
+class PubSubCommandsTest extends UnitTestCase {
+
+  use ProphecyTrait;
+
+  /**
+   * @covers ::__construct
+   * @covers ::listen
+   */
+  public function testListen() : void {
+    $expectedMessage = '{"message":"test"}';
+    $output = $this->prophesize(OutputInterface::class);
+    $input = $this->prophesize(InputInterface::class);
+    $io = $this->prophesize(SymfonyStyle::class);
+    $io->writeln(Argument::containingString('Received message'))
+      ->shouldBeCalledTimes(PubSubCommands::MAX_MESSAGES);
+    $io->writeln(Argument::containingString('Received maximum number of messages'))
+      ->shouldBeCalledTimes(1);
+
+    $manager = $this->prophesize(PubSubManagerInterface::class);
+    $manager->receive()->willReturn($expectedMessage);
+
+    $sut = new PubSubCommands($manager->reveal());
+    $sut->restoreState($input->reveal(), $output->reveal(), $io->reveal());
+    $this->assertEquals(DrushCommands::EXIT_SUCCESS, $sut->listen());
+  }
+
+  /**
+   * @covers ::listen
+   * @covers ::__construct
+   */
+  public function testExceptionOutput() : void {
+    $output = $this->prophesize(OutputInterface::class);
+    $input = $this->prophesize(InputInterface::class);
+    $io = $this->prophesize(SymfonyStyle::class);
+    $io->writeln('Invalid json: Syntax error')->shouldBeCalledTimes(PubSubCommands::MAX_MESSAGES);
+    $io->writeln(Argument::containingString('Received maximum number of messages'))
+      ->shouldBeCalledTimes(1);
+
+    $manager = $this->prophesize(PubSubManagerInterface::class);
+    $manager->receive()->willThrow(new \JsonException('Syntax error'));
+
+    $sut = new PubSubCommands($manager->reveal());
+    $sut->restoreState($input->reveal(), $output->reveal(), $io->reveal());
+    $this->assertEquals(DrushCommands::EXIT_SUCCESS, $sut->listen());
+  }
+
+  /**
+   * @covers ::listen
+   * @covers ::__construct
+   */
+  public function testTimeoutException() : void {
+    $output = $this->prophesize(OutputInterface::class);
+    $input = $this->prophesize(InputInterface::class);
+    $io = $this->prophesize(SymfonyStyle::class);
+    $io->writeln(Argument::containingString('Received maximum number of messages'))
+      ->shouldBeCalledTimes(1);
+
+    $manager = $this->prophesize(PubSubManagerInterface::class);
+    $manager->receive()->willThrow(TimeoutException::class);
+
+    $sut = new PubSubCommands($manager->reveal());
+    $sut->restoreState($input->reveal(), $output->reveal(), $io->reveal());
+    $this->assertEquals(DrushCommands::EXIT_SUCCESS, $sut->listen());
+  }
+
+  /**
+   * @covers ::listen
+   * @covers ::__construct
+   */
+  public function testConnectionException() : void {
+    $this->expectException(ConnectionException::class);
+    $manager = $this->prophesize(PubSubManagerInterface::class);
+    $manager->receive()->willThrow(ConnectionException::class);
+
+    $sut = new PubSubCommands($manager->reveal());
+    $sut->listen();
+  }
+
+}

--- a/tests/src/Unit/Commands/PubSubCommandsTest.php
+++ b/tests/src/Unit/Commands/PubSubCommandsTest.php
@@ -39,6 +39,7 @@ class PubSubCommandsTest extends UnitTestCase {
       ->shouldBeCalledTimes(1);
 
     $manager = $this->prophesize(PubSubManagerInterface::class);
+    $manager->setTimeout(PubSubCommands::CLIENT_TIMEOUT)->shouldBeCalled();
     $manager->receive()->willReturn($expectedMessage);
 
     $sut = new PubSubCommands($manager->reveal());
@@ -59,6 +60,7 @@ class PubSubCommandsTest extends UnitTestCase {
       ->shouldBeCalledTimes(1);
 
     $manager = $this->prophesize(PubSubManagerInterface::class);
+    $manager->setTimeout(PubSubCommands::CLIENT_TIMEOUT)->shouldBeCalled();
     $manager->receive()->willThrow(new \JsonException('Syntax error'));
 
     $sut = new PubSubCommands($manager->reveal());
@@ -78,6 +80,7 @@ class PubSubCommandsTest extends UnitTestCase {
       ->shouldBeCalledTimes(1);
 
     $manager = $this->prophesize(PubSubManagerInterface::class);
+    $manager->setTimeout(PubSubCommands::CLIENT_TIMEOUT)->shouldBeCalled();
     $manager->receive()->willThrow(TimeoutException::class);
 
     $sut = new PubSubCommands($manager->reveal());
@@ -92,6 +95,7 @@ class PubSubCommandsTest extends UnitTestCase {
   public function testConnectionException() : void {
     $this->expectException(ConnectionException::class);
     $manager = $this->prophesize(PubSubManagerInterface::class);
+    $manager->setTimeout(PubSubCommands::CLIENT_TIMEOUT)->shouldBeCalled();
     $manager->receive()->willThrow(ConnectionException::class);
 
     $sut = new PubSubCommands($manager->reveal());

--- a/tests/src/Unit/Environment/EnvironmentTest.php
+++ b/tests/src/Unit/Environment/EnvironmentTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\helfi_api_base\Unit\Environment;
 
 use Drupal\helfi_api_base\Environment\Environment;
 use Drupal\helfi_api_base\Environment\EnvironmentEnum;
+use Drupal\helfi_api_base\Environment\EnvironmentMetadata;
 use Drupal\Tests\UnitTestCase;
 
 /**
@@ -24,15 +25,19 @@ class EnvironmentTest extends UnitTestCase {
    * @covers ::getEnvironment
    * @covers ::getEnvironmentName
    * @covers ::getBaseUrl
+   * @covers ::getMetadata
+   * @covers \Drupal\helfi_api_base\Environment\EnvironmentMetadata::__construct
+   * @covers \Drupal\helfi_api_base\Environment\EnvironmentMetadata::getOpenshiftConsoleLink
    */
   public function testSimpleGetters() : void {
-    $sut = new Environment('www.hel.fi', [], 'https', 'test', EnvironmentEnum::Test, NULL);
+    $sut = new Environment('www.hel.fi', [], 'https', 'test', EnvironmentEnum::Test, new EnvironmentMetadata('https://localhost'));
     $this->assertEquals('test', $sut->getId());
     $this->assertEquals('www.hel.fi', $sut->getDomain());
     $this->assertEquals('https', $sut->getProtocol());
     $this->assertEquals(EnvironmentEnum::Test, $sut->getEnvironment());
     $this->assertEquals(EnvironmentEnum::Test->value, $sut->getEnvironmentName());
     $this->assertEquals('https://www.hel.fi', $sut->getBaseUrl());
+    $this->assertEquals('https://localhost', $sut->getMetadata()->getOpenshiftConsoleLink());
   }
 
   /**

--- a/tests/src/Unit/EventSubscriber/CacheInvalidatorSubscriberTest.php
+++ b/tests/src/Unit/EventSubscriber/CacheInvalidatorSubscriberTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_api_base\Unit\EventSubscriber;
+
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\helfi_api_base\Azure\PubSub\PubSubMessage;
+use Drupal\helfi_api_base\EventSubscriber\CacheInvalidatorSubscriber;
+use Drupal\Tests\UnitTestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+/**
+ * @coversDefaultClass \Drupal\helfi_api_base\EventSubscriber\CacheInvalidatorSubscriber
+ * @group helfi_api_base
+ */
+class CacheInvalidatorSubscriberTest extends UnitTestCase {
+
+  use ProphecyTrait;
+
+  /**
+   * @covers ::__construct
+   * @covers ::onReceive
+   * @covers \Drupal\helfi_api_base\Azure\PubSub\PubSubMessage::__construct
+   */
+  public function testInvalidCacheTags() : void {
+    $invalidator = $this->prophesize(CacheTagsInvalidatorInterface::class);
+    $invalidator->invalidateTags(Argument::any())->shouldNotBeCalled();
+    $sut = new CacheInvalidatorSubscriber($invalidator->reveal());
+    $sut->onReceive(new PubSubMessage([]));
+  }
+
+  /**
+   * @covers ::__construct
+   * @covers ::onReceive
+   * @covers \Drupal\helfi_api_base\Azure\PubSub\PubSubMessage::__construct
+   */
+  public function testValidCacheTags() : void {
+    $invalidator = $this->prophesize(CacheTagsInvalidatorInterface::class);
+    $invalidator->invalidateTags(['node:123'])->shouldBeCalled();
+    $sut = new CacheInvalidatorSubscriber($invalidator->reveal());
+    $sut->onReceive(new PubSubMessage(['tags' => ['node:123']]));
+  }
+
+}

--- a/tests/src/Unit/EventSubscriber/CacheInvalidatorSubscriberTest.php
+++ b/tests/src/Unit/EventSubscriber/CacheInvalidatorSubscriberTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\helfi_api_base\Unit\EventSubscriber;
 use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
 use Drupal\helfi_api_base\Azure\PubSub\PubSubMessage;
 use Drupal\helfi_api_base\EventSubscriber\CacheTagInvalidatorSubscriber;
+use Drupal\Tests\helfi_api_base\Traits\CacheTagInvalidatorTrait;
 use Drupal\Tests\UnitTestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 
@@ -17,6 +18,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
 class CacheInvalidatorSubscriberTest extends UnitTestCase {
 
   use ProphecyTrait;
+  use CacheTagInvalidatorTrait;
 
   /**
    * @covers ::getSubscribedEvents
@@ -38,54 +40,6 @@ class CacheInvalidatorSubscriberTest extends UnitTestCase {
     $invalidator->invalidateTags(['node:123'])->shouldBeCalled();
     $sut = new CacheTagInvalidatorSubscriber($invalidator->reveal());
     $sut->onReceive(new PubSubMessage(['data' => ['tags' => ['node:123']]]));
-  }
-
-  /**
-   * Mock core's CacheTagsInvalidator class.
-   *
-   * The CacheTagsInvalidatorInterface does not define 'resetChecksums()'
-   * method and since the default CacheTagsInvalidator class is marked
-   * as final we cannot mock it.
-   *
-   * @return \Drupal\Core\Cache\CacheTagsInvalidatorInterface
-   *   The cache invalidator class.
-   */
-  private function mockCacheInvalidator() : CacheTagsInvalidatorInterface {
-    return new class () implements CacheTagsInvalidatorInterface {
-
-      /**
-       * A list of invalidated tags.
-       *
-       * @var array
-       */
-      public array $tags = [];
-
-      /**
-       * The number of times resetChecksums has been called.
-       *
-       * @var int
-       */
-      public int $checkSumResets = 0;
-
-      /**
-       * {@inheritdoc}
-       */
-      public function invalidateTags(array $tags) : void {
-        foreach ($tags as $tag) {
-          $this->tags[$tag] = $tag;
-        }
-      }
-
-      /**
-       * Add missing resetChecksums() method.
-       *
-       * @see \Drupal\Core\Cache\CacheTagsInvalidator::resetChecksums()
-       */
-      public function resetChecksums() : void {
-        $this->checkSumResets++;
-      }
-
-    };
   }
 
   /**

--- a/tests/src/Unit/EventSubscriber/CacheInvalidatorSubscriberTest.php
+++ b/tests/src/Unit/EventSubscriber/CacheInvalidatorSubscriberTest.php
@@ -20,6 +20,13 @@ class CacheInvalidatorSubscriberTest extends UnitTestCase {
   use ProphecyTrait;
 
   /**
+   * @covers ::getSubscribedEvents
+   */
+  public function testEvents() : void {
+    $this->assertIsArray(CacheInvalidatorSubscriber::getSubscribedEvents());
+  }
+
+  /**
    * @covers ::__construct
    * @covers ::onReceive
    * @covers \Drupal\helfi_api_base\Azure\PubSub\PubSubMessage::__construct

--- a/tests/src/Unit/EventSubscriber/CacheInvalidatorSubscriberTest.php
+++ b/tests/src/Unit/EventSubscriber/CacheInvalidatorSubscriberTest.php
@@ -47,7 +47,7 @@ class CacheInvalidatorSubscriberTest extends UnitTestCase {
     $invalidator = $this->prophesize(CacheTagsInvalidatorInterface::class);
     $invalidator->invalidateTags(['node:123'])->shouldBeCalled();
     $sut = new CacheTagInvalidatorSubscriber($invalidator->reveal());
-    $sut->onReceive(new PubSubMessage(['tags' => ['node:123']]));
+    $sut->onReceive(new PubSubMessage(['data' => ['tags' => ['node:123']]]));
   }
 
 }

--- a/tests/src/Unit/EventSubscriber/CacheInvalidatorSubscriberTest.php
+++ b/tests/src/Unit/EventSubscriber/CacheInvalidatorSubscriberTest.php
@@ -6,13 +6,13 @@ namespace Drupal\Tests\helfi_api_base\Unit\EventSubscriber;
 
 use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
 use Drupal\helfi_api_base\Azure\PubSub\PubSubMessage;
-use Drupal\helfi_api_base\EventSubscriber\CacheInvalidatorSubscriber;
+use Drupal\helfi_api_base\EventSubscriber\CacheTagInvalidatorSubscriber;
 use Drupal\Tests\UnitTestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
- * @coversDefaultClass \Drupal\helfi_api_base\EventSubscriber\CacheInvalidatorSubscriber
+ * @coversDefaultClass \Drupal\helfi_api_base\EventSubscriber\CacheTagInvalidatorSubscriber
  * @group helfi_api_base
  */
 class CacheInvalidatorSubscriberTest extends UnitTestCase {
@@ -23,7 +23,7 @@ class CacheInvalidatorSubscriberTest extends UnitTestCase {
    * @covers ::getSubscribedEvents
    */
   public function testEvents() : void {
-    $this->assertIsArray(CacheInvalidatorSubscriber::getSubscribedEvents());
+    $this->assertIsArray(CacheTagInvalidatorSubscriber::getSubscribedEvents());
   }
 
   /**
@@ -34,7 +34,7 @@ class CacheInvalidatorSubscriberTest extends UnitTestCase {
   public function testInvalidCacheTags() : void {
     $invalidator = $this->prophesize(CacheTagsInvalidatorInterface::class);
     $invalidator->invalidateTags(Argument::any())->shouldNotBeCalled();
-    $sut = new CacheInvalidatorSubscriber($invalidator->reveal());
+    $sut = new CacheTagInvalidatorSubscriber($invalidator->reveal());
     $sut->onReceive(new PubSubMessage([]));
   }
 
@@ -46,7 +46,7 @@ class CacheInvalidatorSubscriberTest extends UnitTestCase {
   public function testValidCacheTags() : void {
     $invalidator = $this->prophesize(CacheTagsInvalidatorInterface::class);
     $invalidator->invalidateTags(['node:123'])->shouldBeCalled();
-    $sut = new CacheInvalidatorSubscriber($invalidator->reveal());
+    $sut = new CacheTagInvalidatorSubscriber($invalidator->reveal());
     $sut->onReceive(new PubSubMessage(['tags' => ['node:123']]));
   }
 

--- a/tests/src/Unit/Language/DefaultLanguageResolverTest.php
+++ b/tests/src/Unit/Language/DefaultLanguageResolverTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_api_base\Unit\Environment;
+
+use Drupal\Core\Language\Language;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\helfi_api_base\Language\DefaultLanguageResolver;
+use Drupal\Tests\UnitTestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+/**
+ * Tests Default language resolver.
+ *
+ * @coversDefaultClass \Drupal\helfi_api_base\Language\DefaultLanguageResolver
+ * @group helfi_api_base
+ */
+class DefaultLanguageResolverTest extends UnitTestCase {
+
+  use ProphecyTrait;
+
+  /**
+   * @covers ::__construct
+   * @covers ::getDefaultLanguages
+   * @covers ::getFallbackLanguage
+   *
+   * @dataProvider getDefaultLanguagesData
+   */
+  public function testGetDefaultLanguages(
+    array $expectedLanguages,
+    string $expectedLanguage,
+    array $defaultLanguages,
+    string $fallbackLanguage,
+  ) : void {
+    $sut = new DefaultLanguageResolver(
+      $defaultLanguages,
+      $fallbackLanguage,
+      $this->prophesize(LanguageManagerInterface::class)->reveal(),
+    );
+    $this->assertEquals($expectedLanguages, $sut->getDefaultLanguages());
+    $this->assertEquals($expectedLanguage, $sut->getFallbackLanguage());
+  }
+
+  /**
+   * Data provider for default language data.
+   *
+   * @return array
+   *   The data.
+   */
+  public function getDefaultLanguagesData() : array {
+    return [
+      // Test empty.
+      [
+        [],
+        '',
+        [],
+        '',
+      ],
+      [
+        ['en', 'sv', 'fi'],
+        'en',
+        ['en', 'sv', 'fi'],
+        'en',
+      ],
+    ];
+  }
+
+  /**
+   * @covers ::isAltLanguage
+   * @covers ::__construct
+   */
+  public function testIsAltLanguage() : void {
+    $languageManager = $this->prophesize(LanguageManagerInterface::class);
+    $languageManager->getCurrentLanguage()
+      ->willReturn(new Language(Language::$defaultValues))
+      ->shouldBeCalledTimes(2);
+
+    $sut = new DefaultLanguageResolver(['en', 'sv', 'fi'], 'en', $languageManager->reveal());
+
+    $this->assertTrue($sut->isAltLanguage('kr'));
+    $this->assertFalse($sut->isAltLanguage());
+    $this->assertFalse($sut->isAltLanguage(''));
+    $this->assertFalse($sut->isAltLanguage('fi'));
+  }
+
+  /**
+   * @covers ::__construct
+   * @covers ::getFallbackLangAttributes
+   */
+  public function testGetFallBackLangAttributes() : void {
+    $languageManager = $this->prophesize(LanguageManagerInterface::class);
+    $languageManager->getLanguage('en')
+      ->willReturn(new Language(Language::$defaultValues))
+      ->shouldBeCalled();
+    $sut = new DefaultLanguageResolver(['en', 'sv', 'fi'], 'en', $languageManager->reveal());
+    $this->assertEquals([
+      'lang' => Language::$defaultValues['id'],
+      'dir' => Language::$defaultValues['direction'],
+    ], $sut->getFallbackLangAttributes());
+  }
+
+  /**
+   * @covers ::__construct
+   * @covers ::getCurrentLangAttributes
+   */
+  public function testGetCurrentLangAttributes() : void {
+    $languageManager = $this->prophesize(LanguageManagerInterface::class);
+    $languageManager->getCurrentLanguage()
+      ->willReturn(new Language(Language::$defaultValues))
+      ->shouldBeCalled();
+
+    $sut = new DefaultLanguageResolver(['en', 'sv', 'fi'], 'en', $languageManager->reveal());
+    $this->assertEquals([
+      'lang' => Language::$defaultValues['id'],
+      'dir' => Language::$defaultValues['direction'],
+    ], $sut->getCurrentLangAttributes());
+  }
+
+}

--- a/tests/src/Unit/MigrateDataItemTest.php
+++ b/tests/src/Unit/MigrateDataItemTest.php
@@ -13,6 +13,7 @@ use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\migrate\Plugin\MigrationPluginManager;
 use Drupal\Tests\UnitTestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Tests Migrate plugin.
@@ -21,6 +22,8 @@ use Prophecy\Argument;
  * @group helfi_api_base
  */
 class MigrateDataItemTest extends UnitTestCase {
+
+  use ProphecyTrait;
 
   /**
    * Gets the sut.


### PR DESCRIPTION
## How to install
- `composer require drupal/helfi_api_base:dev-UHF-8525`
- `drush cr`
- Add required config overrides to your `local.settings.php`. PM me on Slack for these.
- Add `$config['helfi_global_announcement.settings']['source_environment'] = 'local';` to your `local.settings.php`.

## How to test

- Start the listener: `drush helfi:azure:pubsub-listen`

## Other PRs
- https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/374
- https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/518
