### PR TITLE
UHF-8390 D10 depracation updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "drupal/coder": "^8.3",
-        "donatj/mock-webserver": "dev-master"
+        "donatj/mock-webserver": "dev-master",
+
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "drupal/coder": "^8.3",
-        "donatj/mock-webserver": "dev-master",
-
+        "donatj/mock-webserver": "dev-master"
     }
 }

--- a/src/Entity/Form/MenuLinkFormTrait.php
+++ b/src/Entity/Form/MenuLinkFormTrait.php
@@ -58,7 +58,7 @@ trait MenuLinkFormTrait {
         ->condition('menu_name', array_values($this->getAvailableMenus()), 'IN')
         ->sort('id')
         ->range(0, 1)
-        ->accessCheck(TRUE)
+        ->accessCheck(FALSE)
         ->execute();
 
       $menuLink = empty($results) ? MenuLinkContent::create([]) : MenuLinkContent::load(reset($results));

--- a/src/Entity/Form/MenuLinkFormTrait.php
+++ b/src/Entity/Form/MenuLinkFormTrait.php
@@ -58,6 +58,7 @@ trait MenuLinkFormTrait {
         ->condition('menu_name', array_values($this->getAvailableMenus()), 'IN')
         ->sort('id')
         ->range(0, 1)
+        ->accessCheck(TRUE)
         ->execute();
 
       $menuLink = empty($results) ? MenuLinkContent::create([]) : MenuLinkContent::load(reset($results));

--- a/src/EventSubscriber/MigrationSubscriber.php
+++ b/src/EventSubscriber/MigrationSubscriber.php
@@ -112,7 +112,7 @@ final class MigrationSubscriber implements EventSubscriberInterface {
     $results = $storage
       ->getQuery()
       ->condition('sync_attempts', $entityClass::MAX_SYNC_ATTEMPTS, '>=')
-      ->accessCheck(TRUE)
+      ->accessCheck(FALSE)
       ->execute();
 
     foreach ($results as $id) {

--- a/src/EventSubscriber/MigrationSubscriber.php
+++ b/src/EventSubscriber/MigrationSubscriber.php
@@ -112,6 +112,7 @@ final class MigrationSubscriber implements EventSubscriberInterface {
     $results = $storage
       ->getQuery()
       ->condition('sync_attempts', $entityClass::MAX_SYNC_ATTEMPTS, '>=')
+      ->accessCheck(TRUE)
       ->execute();
 
     foreach ($results as $id) {

--- a/src/Plugin/migrate/source/HttpSourcePluginBase.php
+++ b/src/Plugin/migrate/source/HttpSourcePluginBase.php
@@ -13,6 +13,7 @@ use Drupal\migrate\Plugin\migrate\source\SourcePluginBase;
 use Drupal\migrate\Plugin\MigrationInterface;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Utils;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -176,7 +177,7 @@ abstract class HttpSourcePluginBase extends SourcePluginBase implements Cacheabl
 
     try {
       $content = (string) $this->httpClient->request('GET', $url)->getBody();
-      $content = \GuzzleHttp\json_decode($content, TRUE);
+      $content = Utils::jsonDecode($content, TRUE);
       $this->setCache($url, $content);
 
       return $content ?? [];

--- a/tests/modules/entity_changed_test/entity_changed_test.info.yml
+++ b/tests/modules/entity_changed_test/entity_changed_test.info.yml
@@ -2,4 +2,4 @@ type: module
 name: Entity changed test
 package: Custom
 core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10

--- a/tests/modules/entity_changed_test/entity_changed_test.info.yml
+++ b/tests/modules/entity_changed_test/entity_changed_test.info.yml
@@ -1,5 +1,4 @@
 type: module
 name: Entity changed test
 package: Custom
-core: 8.x
 core_version_requirement: ^9 || ^10

--- a/tests/modules/helfi_locale_test/helfi_locale_test.info.yml
+++ b/tests/modules/helfi_locale_test/helfi_locale_test.info.yml
@@ -1,7 +1,6 @@
 name: HELfi locale test
 type: module
 package: Custom
-core: 8.x
 core_version_requirement: ^9 || ^10
 dependencies:
   - helfi_api_base

--- a/tests/modules/helfi_locale_test/helfi_locale_test.info.yml
+++ b/tests/modules/helfi_locale_test/helfi_locale_test.info.yml
@@ -2,6 +2,6 @@ name: HELfi locale test
 type: module
 package: Custom
 core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - helfi_api_base

--- a/tests/modules/remote_entity_test/remote_entity_test.info.yml
+++ b/tests/modules/remote_entity_test/remote_entity_test.info.yml
@@ -2,7 +2,7 @@ type: module
 name: Remote entity test
 package: Custom
 core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - helfi_api_base
   - menu_link_content

--- a/tests/modules/remote_entity_test/remote_entity_test.info.yml
+++ b/tests/modules/remote_entity_test/remote_entity_test.info.yml
@@ -1,7 +1,6 @@
 type: module
 name: Remote entity test
 package: Custom
-core: 8.x
 core_version_requirement: ^9 || ^10
 dependencies:
   - helfi_api_base

--- a/tests/src/Kernel/MigrationSubscriberTest.php
+++ b/tests/src/Kernel/MigrationSubscriberTest.php
@@ -10,6 +10,7 @@ use Drupal\migrate\Event\MigrateImportEvent;
 use Drupal\migrate\MigrateMessageInterface;
 use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\remote_entity_test\Entity\RemoteEntityTest;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Tests the MigrationSubscriber.
@@ -20,6 +21,7 @@ use Drupal\remote_entity_test\Entity\RemoteEntityTest;
 class MigrationSubscriberTest extends ApiKernelTestBase {
 
   use MigrateTrait;
+  use ProphecyTrait;
 
   /**
    * {@inheritdoc}

--- a/tests/src/Unit/ComposerDataItemTest.php
+++ b/tests/src/Unit/ComposerDataItemTest.php
@@ -10,6 +10,7 @@ use ComposerLockParser\PackagesCollection;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\helfi_api_base\Plugin\DebugDataItem\Composer;
 use Drupal\Tests\UnitTestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Tests Composer plugin.
@@ -18,6 +19,8 @@ use Drupal\Tests\UnitTestCase;
  * @group helfi_api_base
  */
 class ComposerDataItemTest extends UnitTestCase {
+
+  use ProphecyTrait;
 
   /**
    * Creates a new container builder.

--- a/tests/src/Unit/DebugDataResourceTest.php
+++ b/tests/src/Unit/DebugDataResourceTest.php
@@ -14,6 +14,7 @@ use Drupal\helfi_api_base\DebugDataItemPluginManager;
 use Drupal\helfi_api_base\Plugin\rest\resource\DebugDataResource;
 use Drupal\rest\ResourceResponse;
 use Drupal\Tests\UnitTestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -23,6 +24,8 @@ use Psr\Log\LoggerInterface;
  * @group helfi_api_base
  */
 class DebugDataResourceTest extends UnitTestCase {
+
+  use ProphecyTrait;
 
   /**
    * Constructs a fake data item plugin.

--- a/tests/src/Unit/Package/HelfiPackageTest.php
+++ b/tests/src/Unit/Package/HelfiPackageTest.php
@@ -13,6 +13,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Tests Helfi package collector.
@@ -23,6 +24,7 @@ use GuzzleHttp\Psr7\Response;
 class HelfiPackageTest extends UnitTestCase {
 
   use ApiTestTrait;
+  use ProphecyTrait;
 
   /**
    * Tests applies().

--- a/tests/themes/link_template_test_theme/link_template_test_theme.info.yml
+++ b/tests/themes/link_template_test_theme/link_template_test_theme.info.yml
@@ -3,4 +3,4 @@ type: theme
 description: ''
 version: VERSION
 base theme: stark
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10


### PR DESCRIPTION
Added access check to entity queries
Guzzle::jsonDecode to utils::jsonDecode
ProphesizeTrait for prophesize method

How to test:
- composer require drupal/helfi_api_base:dev-UHF-8390
- `composer require drupal/upgrade_status` and `drush en -y upgrade_status`
- run `drush upgrade_status:analyze helfi_api_base`

You should only see deprecation errors from prophecy / prophesize method.