### PR TITLE
Platta 4943 - disable dblog on every deploy

### DIFF
--- a/helfi_api_base.services.yml
+++ b/helfi_api_base.services.yml
@@ -130,3 +130,11 @@ services:
       - '@cache_tags.invalidator'
     tags:
       - { name: event_subscriber }
+
+  helfi_api_base.module_disable_subscriber:
+    class: Drupal\helfi_api_base\EventSubscriber\ModuleDisableSubscriber
+    arguments:
+      - '@module_handler'
+      - '@module_installer'
+    tags:
+      - { name: event_subscriber }

--- a/src/EventSubscriber/ModuleDisableSubscriber.php
+++ b/src/EventSubscriber/ModuleDisableSubscriber.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\EventSubscriber;
+
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Extension\ModuleInstallerInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Handles deploy tasks.
+ */
+final class ModuleDisableSubscriber extends DeployHookEventSubscriberBase {
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler
+   *   The module handler service.
+   * @param \Drupal\Core\Extension\ModuleInstallerInterface $moduleInstaller
+   *   The module installer service.
+   */
+  public function __construct(
+    private readonly ModuleHandlerInterface $moduleHandler,
+    private readonly ModuleInstallerInterface $moduleInstaller
+  ) {
+  }
+
+  /**
+   * Responds to 'helfi_api_base.post_deploy' event.
+   *
+   * @param \Symfony\Contracts\EventDispatcher\Event $event
+   *   The event.
+   */
+  public function onPostDeploy(Event $event) : void {
+    if ($this->moduleHandler->moduleExists('dblog')) {
+      $this->moduleInstaller->uninstall(['dblog']);
+    }
+  }
+
+}

--- a/src/EventSubscriber/ModuleDisableSubscriber.php
+++ b/src/EventSubscriber/ModuleDisableSubscriber.php
@@ -34,6 +34,7 @@ final class ModuleDisableSubscriber extends DeployHookEventSubscriberBase {
    *   The event.
    */
   public function onPostDeploy(Event $event) : void {
+    // Enforce dblog to be disabled as it can cause performance issues.
     if ($this->moduleHandler->moduleExists('dblog')) {
       $this->moduleInstaller->uninstall(['dblog']);
     }


### PR DESCRIPTION
Issue: https://helsinkisolutionoffice.atlassian.net/browse/PLATTA-4943

We disable dblog on every deploy to make sure it is not included in prod env as it may cause performance issues.

This Event subscriber could also serve in future for disabling other modules on deploy.