### PR TITLE
UHF-6542: Added generic hooks to skip/reset migrations

### DIFF
--- a/documentation/migrate.md
+++ b/documentation/migrate.md
@@ -1,5 +1,12 @@
 # Migration
 
+## Migration improvements
+
+`\Drupal\helfi_api_base\Commands\MigrateHookCommands` adds two optional arguments to `migrate:import` command:
+
+- `reset-threshold`: Resets migration status back to `Idle` if migration has been running longer than `reset-threshold`. For example, `--reset-threshold 43200` will reset migration back to `Idle` if the migration has been running for longer than 12 hours
+- `interval`:  Limit how often migration can be run. For example, running the migration import with `--interval 3600` will only run it once an hour, regardless how often it's called
+
 ## Migrate garbage collection
 
 @todo

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -1,4 +1,12 @@
 services:
+  helfi_api_base.migrate_hook_commands:
+    class: \Drupal\helfi_api_base\Commands\MigrateHookCommands
+    arguments:
+      - '@plugin.manager.migration'
+      - '@keyvalue'
+      - '@datetime.time'
+    tags:
+      - { name: drush.command }
   helfi_api_base.pubsub_commands:
     class: \Drupal\helfi_api_base\Commands\PubSubCommands
     arguments:

--- a/src/Commands/MigrateHookCommands.php
+++ b/src/Commands/MigrateHookCommands.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\Commands;
+
+use Consolidation\AnnotatedCommand\CommandData;
+use Consolidation\AnnotatedCommand\Hooks\HookManager;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\Plugin\MigrationPluginManagerInterface;
+use Drush\Attributes\Hook;
+use Drush\Commands\DrushCommands;
+use Drush\Utils\StringUtils;
+use Robo\ResultData;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * Migrate hook commands.
+ */
+final class MigrateHookCommands extends DrushCommands {
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param \Drupal\migrate\Plugin\MigrationPluginManagerInterface $migrationPluginManager
+   *   The migration plugin manager.
+   * @param \Drupal\Core\KeyValueStore\KeyValueFactoryInterface $keyValueFactory
+   *   The key value service.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The time service.
+   */
+  public function __construct(
+    private readonly MigrationPluginManagerInterface $migrationPluginManager,
+    private readonly KeyValueFactoryInterface $keyValueFactory,
+    private readonly TimeInterface $time,
+  ) {
+  }
+
+  /**
+   * Gets the last imported timestamp of a migration.
+   *
+   * @param \Drupal\migrate\Plugin\MigrationInterface $migration
+   *   The migration.
+   *
+   * @return int
+   *   The last imported time.
+   */
+  private function getLastImported(MigrationInterface $migration) : int {
+    $lastImported = $this->keyValueFactory->get('migrate_last_imported')?->get($migration->id(), 0);
+    return (int) round($lastImported / 1000);
+  }
+
+  /**
+   * Checks if a migration interval has been exceeded or not.
+   *
+   * @param \Drupal\migrate\Plugin\MigrationInterface $migration
+   *   The migration.
+   * @param int $seconds
+   *   The interval time.
+   *
+   * @return bool
+   *   TRUE if the interval has been exceeded.
+   */
+  private function migrationIntervalExceeded(MigrationInterface $migration, int $seconds) : bool {
+    $intervalTime = $this->getLastImported($migration) + $seconds;
+    $currentTime = $this->time->getCurrentTime();
+
+    if ($currentTime > $intervalTime) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  /**
+   * Checks whether the migration status should be reset.
+   *
+   * @param \Drupal\migrate\Plugin\MigrationInterface $migration
+   *   The migration.
+   * @param int|null $seconds
+   *   The seconds.
+   *
+   * @return bool
+   *   TRUE if migration should be reset.
+   */
+  private function resetMigration(MigrationInterface $migration, ?int $seconds) : bool {
+    if (!$seconds || $migration->getStatus() === MigrationInterface::STATUS_IDLE) {
+      return FALSE;
+    }
+
+    if (!$this->migrationIntervalExceeded($migration, $seconds)) {
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+  /**
+   * Checks if migration should be skipped or not.
+   *
+   * @param \Drupal\migrate\Plugin\MigrationInterface $migration
+   *   The migration.
+   * @param null|int $seconds
+   *   The interval.
+   *
+   * @return bool
+   *   TRUE if migration should be skipped.
+   */
+  private function skipMigration(MigrationInterface $migration, ?int $seconds) : bool {
+    if (!$seconds) {
+      return FALSE;
+    }
+    return !$this->migrationIntervalExceeded($migration, $seconds);
+  }
+
+  /**
+   * Adds 'interval' and 'reset-threshold' options to migrate:import command.
+   *
+   * @param \Symfony\Component\Console\Command\Command $command
+   *   The command.
+   */
+  #[Hook(type: HookManager::OPTION_HOOK, target: 'migrate:import')]
+  public function addThresholdOption(Command $command) : void {
+    $command->addOption(
+      'interval',
+      mode: InputOption::VALUE_OPTIONAL,
+      description: 'An integer value to determine how often the migration can be run',
+    );
+    $command->addOption(
+      'reset-threshold',
+      mode: InputOption::VALUE_OPTIONAL,
+      description: 'An integer value to determine when a stuck migration should be reset',
+    );
+  }
+
+  /**
+   * Constructs the migration plugins for given IDs.
+   *
+   * @param string $ids
+   *   The migration ids.
+   *
+   * @return \Drupal\migrate\Plugin\MigrationInterface[]
+   *   The migrations.
+   */
+  private function getMigrations(string $ids) : array {
+    $migrationIds = StringUtils::csvToArray($ids);
+    $migrations = $this->migrationPluginManager->createInstances($migrationIds);
+
+    return $migrations ?? [];
+  }
+
+  /**
+   * Checks if the migration status should be reset.
+   *
+   * Reset migration status to 'idle' if the migration has been running for
+   * longer than the value defined in 'reset-threshold' option.
+   *
+   * For example, call 'drush migrate:import tpr_service --reset-threshold 3600'
+   * to reset migration if it has been running for longer than 1 hour.
+   *
+   * @param \Consolidation\AnnotatedCommand\CommandData $commandData
+   *   The command data.
+   *
+   * @return \Robo\ResultData|null
+   *   The result or null.
+   */
+  #[Hook(type: HookManager::PRE_ARGUMENT_VALIDATOR, target: 'migrate:import')]
+  public function resetMigrationsHook(CommandData $commandData) : ?ResultData {
+    $threshold = (int) $commandData->input()->getOption('reset-threshold') ?: NULL;
+
+    if (!$threshold) {
+      return NULL;
+    }
+    $migrations = $this->getMigrations((string) $commandData->input()->getArgument('migrationIds'));
+
+    if (!$migrations) {
+      return NULL;
+    }
+
+    foreach ($migrations as $migration) {
+      if ($this->resetMigration($migration, $threshold)) {
+        $commandData->output()
+          ->writeln(
+            sprintf('<comment>Resetting migrate status: %s</comment>', $migration->id())
+          );
+        // Reset migration status if it has been running for longer than the
+        // configured maximum.
+        $migration->setStatus(MigrationInterface::STATUS_IDLE);
+      }
+    }
+    return new ResultData(message: 'Migrations were reset.');
+  }
+
+  /**
+   * Checks if migrations should be skipped.
+   *
+   * Skip the migration if it has been less than N seconds since the last
+   * run. This can be configured by passing 'interval' option. For example,
+   * call 'drush migrate:import tpr_service --interval 3600' to allow migration
+   * to be run once an hour.
+   *
+   * @return \Robo\ResultData|null
+   *   The result or null.
+   */
+  #[Hook(type: HookManager::PRE_ARGUMENT_VALIDATOR, target: 'migrate:import')]
+  public function skipMigrationsHook(CommandData $commandData) : ?ResultData {
+    $interval = (int) $commandData->input()->getOption('interval') ?: NULL;
+
+    if (!$interval) {
+      return NULL;
+    }
+    $migrations = $this->getMigrations((string) $commandData->input()->getArgument('migrationIds'));
+
+    if (!$migrations) {
+      return NULL;
+    }
+    $skippedMigrations = [];
+
+    foreach ($migrations as $migration) {
+      if ($this->skipMigration($migration, $interval)) {
+        $skippedMigrations[] = $migration->id();
+      }
+    }
+
+    if (!$skippedMigrations) {
+      return NULL;
+    }
+
+    $messages = [];
+    foreach ($skippedMigrations as $id) {
+      $messages[] = sprintf('<comment>Migration "%s" has been run in the past %d seconds. Skipping...</comment>', $id, $interval);
+    }
+    $message = implode(PHP_EOL, $messages);
+
+    $commandData->output()->writeln($message);
+
+    return new ResultData(message: $message);
+  }
+
+}

--- a/src/Commands/MigrateHookCommands.php
+++ b/src/Commands/MigrateHookCommands.php
@@ -54,7 +54,7 @@ final class MigrateHookCommands extends DrushCommands {
   }
 
   /**
-   * Checks if a migration interval has been exceeded or not.
+   * Checks if the migration interval has been exceeded or not.
    *
    * @param \Drupal\migrate\Plugin\MigrationInterface $migration
    *   The migration.

--- a/src/Commands/MigrateHookCommands.php
+++ b/src/Commands/MigrateHookCommands.php
@@ -81,7 +81,7 @@ final class MigrateHookCommands extends DrushCommands {
    *   The command.
    */
   #[Hook(type: HookManager::OPTION_HOOK, target: 'migrate:import')]
-  public function addThresholdOption(Command $command) : void {
+  public function addMigrateHookOptions(Command $command) : void {
     $command->addOption(
       'interval',
       mode: InputOption::VALUE_OPTIONAL,

--- a/src/EventSubscriber/MigrationSubscriber.php
+++ b/src/EventSubscriber/MigrationSubscriber.php
@@ -69,7 +69,7 @@ final class MigrationSubscriber implements EventSubscriberInterface {
 
           return $this->implementsRemoteEntityBase($entityType) ? $entityType : NULL;
         }
-        catch (\Exception $e) {
+        catch (\Exception) {
         }
       }
     }
@@ -141,7 +141,7 @@ final class MigrationSubscriber implements EventSubscriberInterface {
       return;
     }
 
-    // Increment sync counter only when we're not doing a partial migrate.
+    // Increment sync counter only when we're not doing a partial migration.
     // Partial migrates don't save any unchanged entities, leading post-migrate
     // event to delete all unchanged entities.
     if ($this->isPartialMigrate()) {
@@ -168,7 +168,7 @@ final class MigrationSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents() : array {
     return [
       'migrate.pre_import' => ['onPreImport'],
       'migrate.post_import' => ['onPostImport'],

--- a/src/Logger/JsonLog.php
+++ b/src/Logger/JsonLog.php
@@ -4,11 +4,11 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_api_base\Logger;
 
+use Drupal\Core\Logger\LogMessageParserInterface;
 use Drupal\Core\Logger\RfcLoggerTrait;
+use Drupal\Core\Logger\RfcLogLevel;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Psr\Log\LoggerInterface;
-use Drupal\Core\Logger\RfcLogLevel;
-use Drupal\Core\Logger\LogMessageParserInterface;
 
 /**
  * This class allows logging to stdout and stderr.

--- a/tests/src/Kernel/DefaultLanguagesTest.php
+++ b/tests/src/Kernel/DefaultLanguagesTest.php
@@ -5,8 +5,8 @@ declare(strict_types = 1);
 namespace Drupal\Tests\helfi_api_base\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
-use Drupal\Tests\helfi_api_base\Traits\LanguageManagerTrait;
 use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\Tests\helfi_api_base\Traits\LanguageManagerTrait;
 
 /**
  * Tests language resolver functionality.

--- a/tests/src/Unit/Commands/MigrateHookCommandsTest.php
+++ b/tests/src/Unit/Commands/MigrateHookCommandsTest.php
@@ -16,6 +16,7 @@ use Drupal\Tests\UnitTestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Robo\ResultData;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -26,6 +27,22 @@ use Symfony\Component\Console\Output\OutputInterface;
 class MigrateHookCommandsTest extends UnitTestCase {
 
   use ProphecyTrait;
+
+  /**
+   * @covers ::__construct
+   * @covers ::addMigrateHookOptions
+   */
+  public function testAddMigrateHookOptions() : void {
+    $sut = new MigrateHookCommands(
+      $this->prophesize(MigrationPluginManagerInterface::class)->reveal(),
+      $this->prophesize(KeyValueFactoryInterface::class)->reveal(),
+      $this->prophesize(TimeInterface::class)->reveal(),
+    );
+    $command = new Command();
+    $sut->addMigrateHookOptions($command);
+    $this->assertTrue($command->getDefinition()->hasOption('interval'));
+    $this->assertTrue($command->getDefinition()->hasOption('reset-threshold'));
+  }
 
   /**
    * @covers ::skipMigrationsHook

--- a/tests/src/Unit/Commands/MigrateHookCommandsTest.php
+++ b/tests/src/Unit/Commands/MigrateHookCommandsTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_api_base\Unit\Commands;
+
+use Consolidation\AnnotatedCommand\AnnotationData;
+use Consolidation\AnnotatedCommand\CommandData;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
+use Drupal\Core\KeyValueStore\KeyValueStoreInterface;
+use Drupal\helfi_api_base\Commands\MigrateHookCommands;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\Plugin\MigrationPluginManagerInterface;
+use Drupal\Tests\UnitTestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Robo\ResultData;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @coversDefaultClass \Drupal\helfi_api_base\Commands\MigrateHookCommands
+ * @group helfi_api_base
+ */
+class MigrateHookCommandsTest extends UnitTestCase {
+
+  use ProphecyTrait;
+
+  /**
+   * @covers ::skipMigrationsHook
+   * @covers ::resetMigrationsHook
+   */
+  public function testOptionsNotSet() : void {
+    $input = $this->prophesize(InputInterface::class);
+    $output = $this->prophesize(OutputInterface::class);
+    $commandData = new CommandData(new AnnotationData(), $input->reveal(), $output->reveal());
+
+    $sut = new MigrateHookCommands(
+      $this->prophesize(MigrationPluginManagerInterface::class)->reveal(),
+      $this->prophesize(KeyValueFactoryInterface::class)->reveal(),
+      $this->prophesize(TimeInterface::class)->reveal(),
+    );
+    $this->assertNull($sut->skipMigrationsHook($commandData));
+    $this->assertNull($sut->resetMigrationsHook($commandData));
+  }
+
+  /**
+   * @covers ::skipMigrationsHook
+   * @covers ::resetMigrationsHook
+   * @covers ::getMigrations
+   */
+  public function testMigrationsNotFound() : void {
+    $input = $this->prophesize(InputInterface::class);
+    $input->getOption('interval')->willReturn(10);
+    $input->getOption('reset-threshold')->willReturn(10);
+    $input->getArgument('migrationIds')->willReturn(NULL);
+    $output = $this->prophesize(OutputInterface::class);
+    $commandData = new CommandData(new AnnotationData(), $input->reveal(), $output->reveal());
+
+    $sut = new MigrateHookCommands(
+      $this->prophesize(MigrationPluginManagerInterface::class)->reveal(),
+      $this->prophesize(KeyValueFactoryInterface::class)->reveal(),
+      $this->prophesize(TimeInterface::class)->reveal(),
+    );
+    $this->assertNull($sut->skipMigrationsHook($commandData));
+    $this->assertNull($sut->resetMigrationsHook($commandData));
+  }
+
+  /**
+   * @covers ::skipMigrationsHook
+   * @covers ::skipMigration
+   */
+  public function testNoSkippedMigrations() : void {
+    $input = $this->prophesize(InputInterface::class);
+    $input->getArgument('migrationIds')
+      ->willReturn('tpr_unit,tpr_service');
+    $input->getOption('interval')->willReturn(NULL);
+
+    $migrationManager = $this->prophesize(MigrationPluginManagerInterface::class);
+    $migrationManager->createInstances(['tpr_unit', 'tpr_service'])
+      ->willReturn([
+        $this->prophesize(MigrationInterface::class)->reveal(),
+        $this->prophesize(MigrationInterface::class)->reveal(),
+      ]);
+
+    $output = $this->prophesize(OutputInterface::class);
+    $commandData = new CommandData(new AnnotationData(), $input->reveal(), $output->reveal());
+
+    $sut = new MigrateHookCommands(
+      $migrationManager->reveal(),
+      $this->prophesize(KeyValueFactoryInterface::class)->reveal(),
+      $this->prophesize(TimeInterface::class)->reveal(),
+    );
+    $this->assertNull($sut->skipMigrationsHook($commandData));
+  }
+
+  /**
+   * @covers ::skipMigrationsHook
+   * @covers ::skipMigration
+   * @covers ::migrationIntervalExceeded
+   * @covers ::getLastImported
+   */
+  public function testSkipNoMigrationSkipped() : void {
+    $input = $this->prophesize(InputInterface::class);
+    $input->getArgument('migrationIds')
+      ->willReturn('tpr_unit');
+    $input->getOption('interval')->willReturn(43200);
+
+    $migration = $this->prophesize(MigrationInterface::class);
+    $migration->id()->willReturn('tpr_unit');
+
+    $migrationManager = $this->prophesize(MigrationPluginManagerInterface::class);
+    $migrationManager->createInstances(['tpr_unit'])
+      ->willReturn([
+        $migration->reveal(),
+      ]);
+
+    $output = $this->prophesize(OutputInterface::class);
+    $commandData = new CommandData(new AnnotationData(), $input->reveal(), $output->reveal());
+
+    $keyValueStore = $this->prophesize(KeyValueStoreInterface::class);
+    $keyValueStore->get(Argument::any(), Argument::any())->willReturn(NULL);
+
+    $keyValue = $this->prophesize(KeyValueFactoryInterface::class);
+    $keyValue->get('migrate_last_imported')->willReturn($keyValueStore->reveal());
+
+    $time = $this->prophesize(TimeInterface::class);
+    $time->getCurrentTime()->willReturn(1234567);
+
+    $sut = new MigrateHookCommands(
+      $migrationManager->reveal(),
+      $keyValue->reveal(),
+      $time->reveal(),
+    );
+    // Make sure no migration is skipped if the interval has not
+    // exceeded.
+    $this->assertNull($sut->skipMigrationsHook($commandData));
+  }
+
+  /**
+   * @covers ::skipMigrationsHook
+   * @covers ::skipMigration
+   * @covers ::migrationIntervalExceeded
+   * @covers ::getLastImported
+   */
+  public function testMigrationSkipped() : void {
+    $input = $this->prophesize(InputInterface::class);
+    $input->getArgument('migrationIds')
+      ->willReturn('tpr_unit');
+    $input->getOption('interval')->willReturn(10);
+
+    $migration = $this->prophesize(MigrationInterface::class);
+    $migration->id()->willReturn('tpr_unit');
+
+    $migrationManager = $this->prophesize(MigrationPluginManagerInterface::class);
+    $migrationManager->createInstances(['tpr_unit'])
+      ->willReturn([
+        $migration->reveal(),
+      ]);
+
+    $output = $this->prophesize(OutputInterface::class);
+    $commandData = new CommandData(new AnnotationData(), $input->reveal(), $output->reveal());
+
+    $keyValueStore = $this->prophesize(KeyValueStoreInterface::class);
+    // Migrate last imported returns time in microseconds.
+    $keyValueStore->get(Argument::any(), Argument::any())->willReturn(100 * 1000);
+
+    $keyValue = $this->prophesize(KeyValueFactoryInterface::class);
+    $keyValue->get('migrate_last_imported')->willReturn($keyValueStore->reveal());
+
+    $time = $this->prophesize(TimeInterface::class);
+    $time->getCurrentTime()->willReturn(105);
+
+    $sut = new MigrateHookCommands(
+      $migrationManager->reveal(),
+      $keyValue->reveal(),
+      $time->reveal(),
+    );
+    // Make sure migration is skipped since the interval is configured to be 10
+    // seconds, the migration was last run at 100, and the current time is 105.
+    $result = $sut->skipMigrationsHook($commandData);
+    $this->assertInstanceOf(ResultData::class, $result);
+    $this->assertMatchesRegularExpression('/Migration "tpr_unit" has been/', $result->getMessage());
+  }
+
+  /**
+   * @covers ::resetMigrationsHook
+   * @covers ::resetMigration
+   * @covers ::migrationIntervalExceeded
+   * @covers ::getLastImported
+   */
+  public function testMigrationReset() : void {
+    $input = $this->prophesize(InputInterface::class);
+    $input->getArgument('migrationIds')
+      ->willReturn('tpr_unit');
+    $input->getOption('reset-threshold')->willReturn(10);
+
+    $migration = $this->prophesize(MigrationInterface::class);
+    $migration->id()->willReturn('tpr_unit');
+    $migration->getStatus()
+      ->shouldBeCalled()
+      ->willReturn(MigrationInterface::STATUS_IMPORTING);
+    // Make sure migration is set back to idle.
+    $migration->setStatus(MigrationInterface::STATUS_IDLE)->shouldBeCalled();
+
+    $migrationManager = $this->prophesize(MigrationPluginManagerInterface::class);
+    $migrationManager->createInstances(['tpr_unit'])
+      ->willReturn([
+        $migration->reveal(),
+      ]);
+
+    $output = $this->prophesize(OutputInterface::class);
+    $commandData = new CommandData(new AnnotationData(), $input->reveal(), $output->reveal());
+
+    $keyValueStore = $this->prophesize(KeyValueStoreInterface::class);
+    // Migrate last imported returns time in microseconds.
+    $keyValueStore->get(Argument::any(), Argument::any())->willReturn(100 * 1000);
+
+    $keyValue = $this->prophesize(KeyValueFactoryInterface::class);
+    $keyValue->get('migrate_last_imported')->willReturn($keyValueStore->reveal());
+
+    $time = $this->prophesize(TimeInterface::class);
+    $time->getCurrentTime()->willReturn(115);
+
+    $sut = new MigrateHookCommands(
+      $migrationManager->reveal(),
+      $keyValue->reveal(),
+      $time->reveal(),
+    );
+    // Make sure migration is reset back to idle since the migration was last
+    // run at 100, the migration reset-threshold is configured to 10 seconds,
+    // and the current time is 115.
+    $result = $sut->resetMigrationsHook($commandData);
+    $this->assertInstanceOf(ResultData::class, $result);
+  }
+
+}


### PR DESCRIPTION
## How to install
- `composer require drupal/helfi_api_base:dev-UHF-6542`
- `drush cr`

## How to test

- Run migration using `--interval` flag. For example `drush migrate:import tpr_service --interval 60` and make sure the migration is run
- Re-run migration using same command and make sure the migration is skipped
- Set migration state to importing: `drush php-eval "\Drupal::keyValue('migrate_status')->set('tpr_service', 1);"`
- Run migration using `--reset-threshold` flag. For example `drush migrate:import tpr_service --reset-threshold 1232313` and make sure migration fails with `[error]  Migration tpr_service is busy with another operation: Importing` error message
- Re-run migration using lower threshold, for example `drush migrate:import tpr_service --reset-threshold 1` and make sure migration status is reset back to idle