### PR TITLE
PLATTA-4940 use twig for link title only when needed

### DIFF
--- a/templates/helfi-link.html.twig
+++ b/templates/helfi-link.html.twig
@@ -1,1 +1,5 @@
+{#
+  This twig is called only for certain links
+  see conditions in Drupal\helfi_api_base\Link\LinkProcessor::preRenderLink
+#}
 {{ title }}


### PR DESCRIPTION
Currently all type link elements gets the title pass trough a twig.
This causes unnecessary load time, especially if toolbar is present, or a page with lots of links.
One title link rendering takes 0.8- 1.4ms as profiled, and some pages may have 150link + toolbar 300-400 links

I've taken a look into hdbt link twig and replicated the conditions where there's more things printed out besides the title - 
Only in this case it makes sense to actually overwrite the title with a twig.
https://github.com/City-of-Helsinki/drupal-hdbt/blob/main/templates/module/helfi_api_base/helfi-link.html.twig
