### PR TITLE
UHF-8636: debug page item for indexed items

### DIFF
--- a/src/Plugin/DebugDataItem/SearchApiIndex.php
+++ b/src/Plugin/DebugDataItem/SearchApiIndex.php
@@ -1,4 +1,4 @@
-<?php /** @noinspection PhpFieldAssignmentTypeMismatchInspection */
+<?php
 
 declare(strict_types=1);
 
@@ -7,7 +7,6 @@ namespace Drupal\helfi_api_base\Plugin\DebugDataItem;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\helfi_api_base\DebugDataItemPluginBase;
-use Drupal\search_api\Tracker\TrackerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -19,8 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   description = @Translation("SearchApi index")
  * )
  */
-class SearchApiIndex extends DebugDataItemPluginBase implements ContainerFactoryPluginInterface
-{
+class SearchApiIndex extends DebugDataItemPluginBase implements ContainerFactoryPluginInterface {
 
   /**
    * The entity type manager.
@@ -44,19 +42,19 @@ class SearchApiIndex extends DebugDataItemPluginBase implements ContainerFactory
   public function collect(): array {
     $data = ['indexes' => []];
 
-    // @todo: Check if search api is enabled.
+    // @todo Check if search api is enabled.
     try {
       $indexes = $this->entityTypeManager
         ->getStorage('search_api_index')
         ->loadMultiple();
     }
-    catch(\Exception $e) {
+    catch (\Exception $e) {
       return $data;
     }
 
     if ($indexes) {
       /** @var \Drupal\search_api\IndexInterface $index */
-      foreach($indexes as $index) {
+      foreach ($indexes as $index) {
         $tracker = $index->getTrackerInstance();
 
         $result = $this->resolveResult(
@@ -70,7 +68,6 @@ class SearchApiIndex extends DebugDataItemPluginBase implements ContainerFactory
 
     return $data;
   }
-
 
   /**
    * Resolve return value based on index status.

--- a/src/Plugin/DebugDataItem/SearchApiIndex.php
+++ b/src/Plugin/DebugDataItem/SearchApiIndex.php
@@ -1,0 +1,98 @@
+<?php /** @noinspection PhpFieldAssignmentTypeMismatchInspection */
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_api_base\Plugin\DebugDataItem;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\helfi_api_base\DebugDataItemPluginBase;
+use Drupal\search_api\Tracker\TrackerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Plugin implementation of the debug_data_item.
+ *
+ * @DebugDataItem(
+ *   id = "helfi_search_api_index",
+ *   label = @Translation("SearchApi index"),
+ *   description = @Translation("SearchApi index")
+ * )
+ */
+class SearchApiIndex extends DebugDataItemPluginBase implements ContainerFactoryPluginInterface
+{
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = new static($configuration, $plugin_id, $plugin_definition);
+    $instance->entityTypeManager = $container->get('entity_type.manager');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function collect(): array {
+    $data = ['indexes' => []];
+
+    // @todo: Check if search api is enabled.
+    try {
+      $indexes = $this->entityTypeManager
+        ->getStorage('search_api_index')
+        ->loadMultiple();
+    }
+    catch(\Exception $e) {
+      return $data;
+    }
+
+    if ($indexes) {
+      /** @var \Drupal\search_api\IndexInterface $index */
+      foreach($indexes as $index) {
+        $tracker = $index->getTrackerInstance();
+
+        $result = $this->resolveResult(
+          $tracker->getIndexedItemsCount(),
+          $tracker->getTotalItemsCount()
+        );
+
+        $data['indexes'] = [$index->getServerId() => $result];
+      }
+    }
+
+    return $data;
+  }
+
+
+  /**
+   * Resolve return value based on index status.
+   *
+   * @param int $indexed
+   *   Amount of up-to-date items in index.
+   * @param int $total
+   *   Maximum amount of items in index.
+   *
+   * @return string
+   *   Status.
+   */
+  private function resolveResult(int $indexed, int $total): string {
+    if ($indexed == 0 || $total == 0) {
+      return 'indexing or index rebuild required';
+    }
+
+    if ($indexed === $total) {
+      return 'Index up to date';
+    }
+
+    return "$indexed/$total";
+  }
+
+}

--- a/src/Plugin/DebugDataItem/SearchApiIndex.php
+++ b/src/Plugin/DebugDataItem/SearchApiIndex.php
@@ -32,14 +32,14 @@ class SearchApiIndex extends DebugDataItemPluginBase implements ContainerFactory
    *
    * @var null
    */
-  protected $clusterManager = null;
+  protected $clusterManager = NULL;
 
   /**
    * The client manager.
    *
    * @var null
    */
-  protected $clientManager = null;
+  protected $clientManager = NULL;
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/DebugDataItem/SearchApiIndex.php
+++ b/src/Plugin/DebugDataItem/SearchApiIndex.php
@@ -29,7 +29,7 @@ class SearchApiIndex extends DebugDataItemPluginBase implements ContainerFactory
   protected EntityTypeManagerInterface $entityTypeManager;
 
   /**
-   * The module handler.
+   * The module handler interface.
    *
    * @var \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler
    */

--- a/src/Plugin/DebugDataItem/SearchApiIndex.php
+++ b/src/Plugin/DebugDataItem/SearchApiIndex.php
@@ -29,7 +29,7 @@ class SearchApiIndex extends DebugDataItemPluginBase implements ContainerFactory
   protected EntityTypeManagerInterface $entityTypeManager;
 
   /**
-   * Module handler.
+   * The module handler.
    *
    * @var \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler
    */
@@ -91,7 +91,6 @@ class SearchApiIndex extends DebugDataItemPluginBase implements ContainerFactory
         ];
       }
     }
-
 
     return $data;
   }

--- a/src/Plugin/DebugDataItem/SearchApiIndex.php
+++ b/src/Plugin/DebugDataItem/SearchApiIndex.php
@@ -29,9 +29,9 @@ class SearchApiIndex extends DebugDataItemPluginBase implements ContainerFactory
   protected EntityTypeManagerInterface $entityTypeManager;
 
   /**
-   * The module handler interface.
+   * The module handler.
    *
-   * @var \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
    */
   protected ModuleHandlerInterface $moduleHandler;
 

--- a/src/Plugin/DebugDataItem/SearchApiIndex.php
+++ b/src/Plugin/DebugDataItem/SearchApiIndex.php
@@ -28,6 +28,20 @@ class SearchApiIndex extends DebugDataItemPluginBase implements ContainerFactory
   protected EntityTypeManagerInterface $entityTypeManager;
 
   /**
+   * The cluster manager.
+   *
+   * @var null
+   */
+  protected $clusterManager = null;
+
+  /**
+   * The client manager.
+   *
+   * @var null
+   */
+  protected $clientManager = null;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {

--- a/src/Plugin/DebugDataItem/SearchApiIndex.php
+++ b/src/Plugin/DebugDataItem/SearchApiIndex.php
@@ -9,7 +9,6 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\helfi_api_base\DebugDataItemPluginBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-
 /**
  * Plugin implementation of the debug_data_item.
  *


### PR DESCRIPTION
# [UHF-8636](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8636)
Allow showing SearchApi index status on dashboard


## How to install
Select one of the environments with elasticsearch set up (Kasko for example)
You should also test this with a site without searchapi enabled to make sure nothing breaks.

- Make sure your instance is up and running on latest dev branch.
  - git pull origin dev
  - make fresh
- Update the Helfi api base
  - composer require drupal/helfi_api_base:dev-UHF-8636_index_debug
- Run make drush-updb drush-cr


## How to test

- Go to see the api result from `/api/v1/debug`
- You should see `helfi_search_api_index` key within the result
  - The message for the index should tell you to `run the indexing or rebuild the index`.
- Go to `/admin/config/search/search-api`
  - Select an active index and click the name (for example `School` in kasko)    
- Click `Rebuild tracking information`
  - Go to see the api result. You should see the same message
- Now go and run only `1 batch of 50 items` 
  - Go to see the api result. You should see the amount of items indexed, for example `(50/134000)`
- Now go and run the full indexing
  - Go to see the api result. You should see a message telling you that `Index up to date`.

Test this with any other site without elasticsearch (kuva?). Open the api search result and you should see it.
Also open debug page and see that it works as well.

## Other PRs


[UHF-8636]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ