### PR TITLE
UHF-8945: disable email sending. 

### DIFF
--- a/helfi_api_base.module
+++ b/helfi_api_base.module
@@ -55,7 +55,7 @@ function helfi_api_base_theme_suggestions_debug_item(array $variables) : array {
  * Implements hook_mail_alter().
  */
 function helfi_api_base_mail_alter(&$message) : void {
-  // Prevent sending an email if current site/environment is unknown to the resolver.
+  // Prevent sending an email if current site/environment is known to the resolver.
   // Only helfi-drupal sites are affected by this change.
   try {
     \Drupal::service('helfi_api_base.environment_resolver')

--- a/helfi_api_base.module
+++ b/helfi_api_base.module
@@ -50,3 +50,16 @@ function helfi_api_base_theme_suggestions_debug_item(array $variables) : array {
   $suggestions[] = 'debug_item__' . strtr($variables['id'], '.', '_');
   return $suggestions;
 }
+
+/**
+ * Implements hook_mail_alter().
+ */
+function helfi_api_base_mail_alter(&$message) : void {
+  $environmentResolver = \Drupal::service('helfi_api_base.environment_resolver');
+  try {
+    $environmentResolver->getActiveEnvironment();
+    $message['send'] = FALSE;
+  }
+  catch (\InvalidArgumentException) {
+  }
+}

--- a/helfi_api_base.module
+++ b/helfi_api_base.module
@@ -55,9 +55,11 @@ function helfi_api_base_theme_suggestions_debug_item(array $variables) : array {
  * Implements hook_mail_alter().
  */
 function helfi_api_base_mail_alter(&$message) : void {
-  $environmentResolver = \Drupal::service('helfi_api_base.environment_resolver');
+  // Prevent sending an email if current site/environment is unknown to the resolver.
+  // Only helfi-drupal sites are affected by this change.
   try {
-    $environmentResolver->getActiveEnvironment();
+    \Drupal::service('helfi_api_base.environment_resolver')
+      ->getActiveEnvironment();
     $message['send'] = FALSE;
   }
   catch (\InvalidArgumentException) {

--- a/helfi_api_base.module
+++ b/helfi_api_base.module
@@ -55,7 +55,7 @@ function helfi_api_base_theme_suggestions_debug_item(array $variables) : array {
  * Implements hook_mail_alter().
  */
 function helfi_api_base_mail_alter(&$message) : void {
-  // Prevent sending an email if current site/environment is known to the resolver.
+  // Prevent sending email if current site/environment is known to the resolver.
   // Only helfi-drupal sites are affected by this change.
   try {
     \Drupal::service('helfi_api_base.environment_resolver')


### PR DESCRIPTION
Set up site normally

Reproduce error:
- `make shell`, run `drush cron`
  - At some point you should see an error about email sending
- Run `drush cron` again. 
  - You should see the same error again 

Fix:
- `composer require drupal/helfi_api_base:dev-UHF-8945_disable_email`
- Run `drush cr`
- Run `drush cron`
  - The error is not shown anymore 