### PR TITLE
UHF-6294: Allow weight to be changed

### DIFF
--- a/src/Entity/Form/MenuLinkFormTrait.php
+++ b/src/Entity/Form/MenuLinkFormTrait.php
@@ -151,6 +151,13 @@ trait MenuLinkFormTrait {
       ->menuParentSelector
       ->parentSelectElement($default, $id, $this->getAvailableMenus());
 
+    $form['menu']['link']['weight'] = [
+      '#type' => 'number',
+      '#title' => t('Weight'),
+      '#default_value' => $menuLink->getWeight(),
+      '#description' => $this->t('Menu links with lower weights are displayed before links with higher weights.'),
+    ];
+
     $form['actions']['submit']['#submit'][] = '::attachMenuLinkFormSubmit';
 
     return $form;
@@ -199,6 +206,7 @@ trait MenuLinkFormTrait {
         ->set('menu_name', $menuName)
         ->set('parent', $parent)
         ->set('langcode', $entity->language()->getId())
+        ->set('weight', $values['weight'])
         ->save();
 
       $entity->set($this->menuLinkFieldName, $menuLink)->save();

--- a/tests/src/Functional/MenuLinkFormTest.php
+++ b/tests/src/Functional/MenuLinkFormTest.php
@@ -96,6 +96,7 @@ class MenuLinkFormTest extends BrowserTestBase {
       $this->submitForm([
         'menu[enabled]' => 1,
         'menu[title]' => 'Test title ' . $langcode,
+        'menu[weight]' => 9,
       ], 'Save');
 
       // Make sure menu link is show in edit form.
@@ -119,6 +120,7 @@ class MenuLinkFormTest extends BrowserTestBase {
         ->entity
         ->getTranslation($langcode);
 
+      $this->assertEquals(9, $menuLink->getWeight());
       $this->assertEquals('Test title ' . $langcode, $menuLink->getTitle());
     }
 


### PR DESCRIPTION
See https://helsinkisolutionoffice.atlassian.net/browse/UHF-6294

## How to install
- `composer require drupal/helfi_api_base:dev-UHF-6294`

## How to test

- [x] Make sure menu link's weight can be changed on TPR unit/service edit page