### PR TITLE
UHF-7324: Support deleting old revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A base module for [drupal-helfi-platform](https://github.com/City-of-Helsinki/dr
 
 - [API user manager](documentation/api-accounts.md): Allows API users to be created/managed from an environment variable.
 - [Automatic external cache invalidation](documentation/automatic-external-cache-invalidation.md): Invalidate caches from external projects using [PubSub messaging](documentation/pubsub-messaging.md) service.
+- [Automatic revision deletion](documentation/revisions.md): Clean up old entity revisions automatically.
 - [Debug collector](documentation/debug.md): A plugin to collect and show various debug information in one place.
 - [Deploy hooks](documentation/deploy-hooks.md): Allows custom tasks to be run before or after deployment.
 - [Environment resolver](documentation/environment-resolver.md): A service to fetch metadata for given project.

--- a/config/schema/helfi_api_base.schema.yml
+++ b/config/schema/helfi_api_base.schema.yml
@@ -39,3 +39,11 @@ helfi_api_base.environment_resolver.settings:
     project_name:
       type: string
       label: 'The currently active project name'
+
+helfi_api_base.delete_revisions:
+  type: config_entity
+  mapping:
+    entity_types:
+      type: sequence
+      sequence:
+        type: string

--- a/documentation/revisions.md
+++ b/documentation/revisions.md
@@ -1,0 +1,36 @@
+# Automatic entity revision deletion
+
+Allows old revisions to be deleted. By default, five revisions are kept per entity translation.
+
+## Configuration
+
+This can be configured in code with:
+```php
+
+# public/sites/default/*.settings.php
+$config['helfi_api_base.delete_revisions']['entity_types'] = [
+  'node',
+  'paragraph',
+  'tpr_unit',
+  'tpr_service',
+  'tpr_errand_service',
+];
+```
+
+or by creating a configuration yml file:
+
+```yaml
+# conf/cmi/helfi_api_base.delete_revisions.yml
+entity_types:
+  - node
+  - paragraph
+  - tpr_unit
+  - tpr_service
+  - tpr_errand_service
+```
+
+## Usage
+
+All configured entities are queued for clean up on entity save.
+
+To clean up existing entities at once, run: `drush helfi:revision:delete {entity_type}`.

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -38,3 +38,11 @@ services:
     arguments: ['@language_manager', '@file_system', '@string_translation', '@extension.list.module']
     tags:
       - { name: drush.command }
+  helfi_api_base.revision_commands:
+    class: \Drupal\helfi_api_base\Commands\RevisionCommands
+    arguments:
+      - '@helfi_api_base.revision_manager'
+      - '@entity_type.manager'
+      - '@database'
+    tags:
+      - { name: drush.command }

--- a/helfi_api_base.install
+++ b/helfi_api_base.install
@@ -171,3 +171,26 @@ function helfi_api_base_update_9009() : void {
 function helfi_api_base_update_9013() : void {
   helfi_api_base_install();
 }
+
+/**
+ * Enable 'delete old revisions' feature.
+ */
+function helfi_api_base_update_9014() : void {
+  /** @var \Drupal\helfi_api_base\Environment\EnvironmentResolverInterface $service */
+  $service = \Drupal::service('helfi_api_base.environment_resolver');
+  try {
+    $service->getActiveProject();
+
+    \Drupal::configFactory()->getEditable('helfi_api_base.delete_revisions')
+      ->set('entity_types', [
+        'node',
+        'paragraph',
+        'tpr_unit',
+        'tpr_service',
+        'tpr_errand_service',
+      ])->save();
+  }
+  catch (\InvalidArgumentException) {
+  }
+
+}

--- a/helfi_api_base.module
+++ b/helfi_api_base.module
@@ -7,6 +7,7 @@
 
 declare(strict_types = 1);
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\helfi_api_base\Link\LinkProcessor;
 
 /**
@@ -63,5 +64,27 @@ function helfi_api_base_mail_alter(&$message) : void {
     $message['send'] = FALSE;
   }
   catch (\InvalidArgumentException) {
+  }
+}
+
+/**
+ * Implements hook_entity_update().
+ */
+function helfi_api_base_entity_update(EntityInterface $entity) : void {
+  /** @var \Drupal\helfi_api_base\Entity\Revision\RevisionManager $revisionManager */
+  $revisionManager = \Drupal::service('helfi_api_base.revision_manager');
+
+  if (!$revisionManager->entityTypeIsSupported($entity->getEntityTypeId())) {
+    return;
+  }
+  $revisions = $revisionManager->getRevisions($entity->getEntityTypeId(), $entity->id());
+
+  // Queue old revisions for deletion.
+  if ($revisions) {
+    $queue = \Drupal::queue('helfi_api_base_revision');
+    $queue->createItem([
+      'entity_id' => $entity->id(),
+      'entity_type' => $entity->getEntityTypeId(),
+    ]);
   }
 }

--- a/helfi_api_base.module
+++ b/helfi_api_base.module
@@ -79,7 +79,7 @@ function helfi_api_base_entity_update(EntityInterface $entity) : void {
   }
   $revisions = $revisionManager->getRevisions($entity->getEntityTypeId(), $entity->id());
 
-  // Queue old revisions for deletion.
+  // Queue entity revisions for deletion.
   if ($revisions) {
     $queue = \Drupal::queue('helfi_api_base_revision');
     $queue->createItem([

--- a/helfi_api_base.services.yml
+++ b/helfi_api_base.services.yml
@@ -129,3 +129,10 @@ services:
       - '@cache_tags.invalidator'
     tags:
       - { name: event_subscriber }
+
+  helfi_api_base.revision_manager:
+    class: Drupal\helfi_api_base\Entity\Revision\RevisionManager
+    arguments:
+      - '@entity_type.manager'
+      - '@config.factory'
+      - '@database'

--- a/src/Commands/RevisionCommands.php
+++ b/src/Commands/RevisionCommands.php
@@ -19,6 +19,13 @@ final class RevisionCommands extends DrushCommands {
 
   /**
    * Constructs a new instance.
+   *
+   * @param \Drupal\helfi_api_base\Entity\Revision\RevisionManager $revisionManager
+   *   The revision manager service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager service.
+   * @param \Drupal\Core\Database\Connection $connection
+   *   The connection service.
    */
   public function __construct(
     private readonly RevisionManager $revisionManager,

--- a/src/Commands/RevisionCommands.php
+++ b/src/Commands/RevisionCommands.php
@@ -60,7 +60,7 @@ final class RevisionCommands extends DrushCommands {
       ->fetchCol();
 
     $totalEntities = $remainingEntities = count($entityIds);
-    $this->io()->writeln(new FormattableMarkup('Found @count @type entities', [
+    $this->io()->writeln((string) new FormattableMarkup('Found @count @type entities', [
       '@count' => $totalEntities,
       '@type' => $entityType,
     ]));
@@ -72,9 +72,9 @@ final class RevisionCommands extends DrushCommands {
       $message = sprintf('Entity has less than %s revisions. Skipping', $options['keep']);
 
       if ($revisionCount > 0) {
-        $message = new FormattableMarkup('Deleting @count revisions', ['@count' => $revisionCount]);
+        $message = (string) new FormattableMarkup('Deleting @count revisions', ['@count' => $revisionCount]);
       }
-      $this->io()->writeln(new FormattableMarkup('[@current/@entities] @message ...', [
+      $this->io()->writeln((string) new FormattableMarkup('[@current/@entities] @message ...', [
         '@current' => $remainingEntities--,
         '@entities' => $totalEntities,
         '@message' => $message,

--- a/src/Commands/RevisionCommands.php
+++ b/src/Commands/RevisionCommands.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_api_base\Commands;
+
+use Drupal\Component\Render\FormattableMarkup;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\helfi_api_base\Entity\Revision\RevisionManager;
+use Drush\Attributes\Command;
+use Drush\Attributes\Option;
+use Drush\Commands\DrushCommands;
+
+/**
+ * A drush command file to manage revisions.
+ */
+final class RevisionCommands extends DrushCommands {
+
+  /**
+   * Constructs a new instance.
+   */
+  public function __construct(
+    private readonly RevisionManager $revisionManager,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly Connection $connection,
+  ) {
+  }
+
+  /**
+   * Deletes the old revisions.
+   *
+   * @param string $entityType
+   *   The entity type.
+   * @param array $options
+   *   The options.
+   *
+   * @return int
+   *   The exit code.
+   */
+  #[Command(name: 'helfi:revision:delete')]
+  #[Option(name: 'keep', description: 'Number of revisions to keep')]
+  public function delete(string $entityType, array $options = ['keep' => RevisionManager::KEEP_REVISIONS]) : int {
+    if (!$this->revisionManager->entityTypeIsSupported($entityType)) {
+      $this->io()->writeln('Given entity type is not supported.');
+      return DrushCommands::EXIT_SUCCESS;
+    }
+
+    $definition = $this->entityTypeManager->getDefinition($entityType);
+    $entityIds = $this->connection->select($definition->getBaseTable(), 't')
+      ->fields('t', [$definition->getKey('id')])
+      ->execute()
+      ->fetchCol();
+
+    $totalEntities = $remainingEntities = count($entityIds);
+    $this->io()->writeln(new FormattableMarkup('Found @count @type entities', [
+      '@count' => $totalEntities,
+      '@type' => $entityType,
+    ]));
+
+    foreach ($entityIds as $id) {
+      $revisions = $this->revisionManager->getRevisions($entityType, $id, $options['keep']);
+      $revisionCount = count($revisions);
+
+      $message = sprintf('Entity has less than %s revisions. Skipping', $options['keep']);
+
+      if ($revisionCount > 0) {
+        $message = new FormattableMarkup('Deleting @count revisions', ['@count' => $revisionCount]);
+      }
+      $this->io()->writeln(new FormattableMarkup('[@current/@entities] @message ...', [
+        '@current' => $remainingEntities--,
+        '@entities' => $totalEntities,
+        '@message' => $message,
+      ]));
+      $this->revisionManager->deleteRevisions($entityType, $revisions);
+    }
+
+    return DrushCommands::EXIT_SUCCESS;
+  }
+
+}

--- a/src/Entity/Revision/RevisionManager.php
+++ b/src/Entity/Revision/RevisionManager.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\Entity\Revision;
+
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
+use Drupal\Component\Render\FormattableMarkup;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * A class to manage revisions.
+ */
+final class RevisionManager {
+
+  public const KEEP_REVISIONS = 5;
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
+   * @param \Drupal\Core\Database\Connection $connection
+   *   The database connection.
+   */
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly ConfigFactoryInterface $configFactory,
+    private readonly Connection $connection,
+  ) {
+  }
+
+  /**
+   * Gets the supported entity types.
+   *
+   * @return array
+   *   An array of entity types.
+   */
+  public function getSupportedEntityTypes() : array {
+    return $this->configFactory
+      ->get('helfi_api_base.delete_revisions')
+      ->get('entity_types') ?? [];
+  }
+
+  /**
+   * Asserts that entity type is supported.
+   *
+   * @param string $entityType
+   *   The entity type to check.
+   */
+  private function assertEntityType(string $entityType) : void {
+    if (!in_array($entityType, $this->getSupportedEntityTypes())) {
+      throw new \InvalidArgumentException('Entity type is not supported.');
+    }
+    try {
+      $definition = $this->entityTypeManager->getDefinition($entityType);
+
+      if (!$definition->isRevisionable()) {
+        throw new \InvalidArgumentException('Entity type does not support revisions.');
+      }
+    }
+    catch (PluginNotFoundException $e) {
+      throw new \InvalidArgumentException('Invalid entity type.', previous: $e);
+    }
+  }
+
+  /**
+   * Checks whether the given entity type is supported or not.
+   *
+   * @param string $entityType
+   *   The entity type to check.
+   *
+   * @return bool
+   *   TRUE if the entity type is supported.
+   */
+  public function entityTypeIsSupported(string $entityType) : bool {
+    try {
+      $this->assertEntityType($entityType);
+
+      return TRUE;
+    }
+    catch (\InvalidArgumentException) {
+    }
+    return FALSE;
+  }
+
+  /**
+   * Deletes the previous revisions for the given entity type and ids.
+   *
+   * @param string $entityType
+   *   The entity type.
+   * @param array $ids
+   *   The version ids.
+   */
+  public function deleteRevisions(string $entityType, array $ids) : void {
+    $this->assertEntityType($entityType);
+
+    $storage = $this->entityTypeManager
+      ->getStorage($entityType);
+
+    foreach ($ids as $id) {
+      $storage->deleteRevision($id);
+    }
+  }
+
+  /**
+   * Gets the revisions for given entity type and id.
+   *
+   * Grouped by language to make testing easier.
+   *
+   * @param string $entityType
+   *   The entity type.
+   * @param string|int $id
+   *   The entity id.
+   * @param int $keep
+   *   The number of revisions to keep.
+   *
+   * @return array
+   *   An array of revision IDs.
+   */
+  public function getRevisionsPerLanguage(
+    string $entityType,
+    string|int $id,
+    int $keep = self::KEEP_REVISIONS
+  ) : array {
+    $this->assertEntityType($entityType);
+
+    $storage = $this->entityTypeManager->getStorage($entityType);
+    $definition = $this->entityTypeManager->getDefinition($entityType);
+
+    $revision_ids = $this->connection->query(
+      (string) new FormattableMarkup('SELECT [@vid] FROM {@table} WHERE [@id] = :id ORDER BY [@vid]', [
+        '@vid' => $definition->getKey('revision'),
+        '@table' => $definition->getRevisionTable(),
+        '@id' => $definition->getKey('id'),
+      ]),
+      [':id' => $id]
+    )->fetchCol();
+
+    $revisions = [];
+
+    if (count($revision_ids) === 0) {
+      return [];
+    }
+    krsort($revision_ids);
+
+    foreach ($revision_ids as $vid) {
+      /** @var \Drupal\Core\Entity\RevisionableInterface $revision */
+      $revision = $storage->loadRevision($vid);
+
+      foreach ($revision->getTranslationLanguages() as $langcode => $language) {
+        if ($revision->hasTranslation($langcode) && $revision->getTranslation($langcode)->isRevisionTranslationAffected()) {
+          $revisions[$langcode][] = $revision->getLoadedRevisionId();
+        }
+      }
+    }
+
+    foreach ($revisions as $langcode => $items) {
+      $revisions[$langcode] = array_slice($items, $keep);
+    }
+
+    return $revisions;
+  }
+
+  /**
+   * Gets revisions for given entity type and id.
+   *
+   * @param string $entityType
+   *   The entity type.
+   * @param string|int $id
+   *   The entity ID.
+   * @param int $keep
+   *   The number of revisions to keep.
+   *
+   * @return array
+   *   An array of revision ids.
+   */
+  public function getRevisions(string $entityType, string|int $id, int $keep = self::KEEP_REVISIONS) : array {
+    $revisions = $this->getRevisionsPerLanguage($entityType, $id, $keep);
+
+    return array_unique(array_merge(...array_values($revisions)));
+  }
+
+}

--- a/src/Entity/Revision/RevisionManager.php
+++ b/src/Entity/Revision/RevisionManager.php
@@ -13,7 +13,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 /**
  * A class to manage revisions.
  */
-final class RevisionManager {
+class RevisionManager {
 
   public const KEEP_REVISIONS = 5;
 
@@ -93,16 +93,16 @@ final class RevisionManager {
    *
    * @param string $entityType
    *   The entity type.
-   * @param array $ids
+   * @param array $revisionIds
    *   The version ids.
    */
-  public function deleteRevisions(string $entityType, array $ids) : void {
+  public function deleteRevisions(string $entityType, array $revisionIds) : void {
     $this->assertEntityType($entityType);
 
     $storage = $this->entityTypeManager
       ->getStorage($entityType);
 
-    foreach ($ids as $id) {
+    foreach ($revisionIds as $id) {
       $storage->deleteRevision($id);
     }
   }
@@ -167,7 +167,7 @@ final class RevisionManager {
   }
 
   /**
-   * Gets revisions for given entity type and id.
+   * Gets revisions for the given entity type and id.
    *
    * @param string $entityType
    *   The entity type.

--- a/src/Plugin/QueueWorker/RevisionQueue.php
+++ b/src/Plugin/QueueWorker/RevisionQueue.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_api_base\Plugin\QueueWorker;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Queue\QueueWorkerBase;
+use Drupal\helfi_api_base\Entity\Revision\RevisionManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Handles old revision deletion.
+ *
+ * @QueueWorker(
+ *  id = "helfi_api_base_revision",
+ *  title = @Translation("Queue worker for deleting old revisions"),
+ *  cron = {"time" = 180}
+ * )
+ */
+final class RevisionQueue extends QueueWorkerBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The revision manager.
+   *
+   * @var \Drupal\helfi_api_base\Entity\Revision\RevisionManager
+   */
+  private RevisionManager $revisionManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) : self {
+    $instance = new self($configuration, $plugin_id, $plugin_definition);
+    $instance->revisionManager = $container->get('helfi_api_base.revision_manager');
+    return $instance;
+  }
+
+  /**
+   * Process queue item.
+   *
+   * @param array|mixed $data
+   *   The queue data. Should contain 'entity_id' and 'entity_type'.
+   */
+  public function processItem($data) : void {
+    if (!isset($data['entity_id'], $data['entity_type'])) {
+      return;
+    }
+    ['entity_id' => $id, 'entity_type' => $type] = $data;
+
+    $revisions = $this->revisionManager->getRevisions($type, $id);
+
+    if ($revisions) {
+      $this->revisionManager->deleteRevisions($type, $revisions);
+    }
+  }
+
+}

--- a/tests/modules/remote_entity_test/src/Entity/RemoteEntityTest.php
+++ b/tests/modules/remote_entity_test/src/Entity/RemoteEntityTest.php
@@ -7,6 +7,7 @@ namespace Drupal\remote_entity_test\Entity;
 use Drupal\Core\Entity\EntityPublishedInterface;
 use Drupal\Core\Entity\EntityPublishedTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\RevisionableInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\helfi_api_base\Entity\RemoteEntityBase;
@@ -37,9 +38,17 @@ use Drupal\user\EntityOwnerTrait;
  *   data_table = "rmt_field_data",
  *   admin_permission = "administer remote entities",
  *   translatable = TRUE,
+ *   revision_table = "rmt_revision",
+ *   revision_data_table = "rmt_field_revision",
+ *   revision_metadata_keys = {
+ *     "revision_user" = "revision_uid",
+ *     "revision_created" = "revision_timestamp",
+ *     "revision_log_message" = "revision_log"
+ *   },
  *   entity_keys = {
  *     "id" = "id",
  *     "langcode" = "langcode",
+ *     "revision" = "vid",
  *     "label" = "name",
  *     "uuid" = "uuid",
  *     "published" = "content_translation_status",
@@ -53,7 +62,7 @@ use Drupal\user\EntityOwnerTrait;
  *   },
  * )
  */
-final class RemoteEntityTest extends RemoteEntityBase implements EntityPublishedInterface, EntityOwnerInterface {
+final class RemoteEntityTest extends RemoteEntityBase implements EntityPublishedInterface, EntityOwnerInterface, RevisionableInterface {
 
   use EntityPublishedTrait;
   use EntityOwnerTrait;
@@ -74,6 +83,7 @@ final class RemoteEntityTest extends RemoteEntityBase implements EntityPublished
     $fields['name'] = BaseFieldDefinition::create('string')
       ->setLabel(new TranslatableMarkup('Name'))
       ->setTranslatable(TRUE)
+      ->setRevisionable(TRUE)
       ->setDefaultValue('')
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayConfigurable('form', TRUE)

--- a/tests/src/Kernel/Entity/Revision/RevisionManagerTest.php
+++ b/tests/src/Kernel/Entity/Revision/RevisionManagerTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_api_base\Kernel\Entity\Revision;
+
+use Drupal\helfi_api_base\Entity\Revision\RevisionManager;
+use Drupal\Tests\helfi_api_base\Kernel\ApiKernelTestBase;
+use Drupal\Tests\helfi_api_base\Traits\LanguageManagerTrait;
+
+/**
+ * Tests revision manager.
+ *
+ * @group helfi_api_base
+ */
+class RevisionManagerTest extends ApiKernelTestBase {
+
+  use LanguageManagerTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'helfi_api_base',
+    'helfi_language_negotiator_test',
+    'language',
+    'user',
+    'link',
+    'menu_link_content',
+    'system',
+    'content_translation',
+    'remote_entity_test',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() : void {
+    parent::setUp();
+
+    $this->setupLanguages();
+    $this->installEntitySchema('menu_link_content');
+    $this->installEntitySchema('remote_entity_test');
+  }
+
+  /**
+   * Sets the allowed revision entity types.
+   *
+   * @param array $entityTypes
+   *   The entity types.
+   */
+  private function setEntityTypes(array $entityTypes) : void {
+    $this->config('helfi_api_base.delete_revisions')
+      ->set('entity_types', $entityTypes)
+      ->save();
+  }
+
+  /**
+   * Gets the SUT.
+   *
+   * @return \Drupal\helfi_api_base\Entity\Revision\RevisionManager
+   *   The sut.
+   */
+  private function getSut() : RevisionManager {
+    return $this->container->get('helfi_api_base.revision_manager');
+  }
+
+  /**
+   * Make sure an exception is throw when the entity type is not supported.
+   */
+  public function testEntityTypeNotSupportedException() : void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('Entity type is not supported.');
+    $this->getSut()->deleteRevisions('node', [1]);
+  }
+
+  /**
+   * Make sure an exception is thrown when the entity type does not exist.
+   */
+  public function testDeletePreviousRevisionsException() : void {
+    $this->setEntityTypes(['node']);
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('Invalid entity type.');
+    $this->getSut()->deleteRevisions('node', ['1']);
+  }
+
+  /**
+   * Make sure an exception is thrown when the entity type does not exist.
+   */
+  public function testGetPreviousRevisionsException() : void {
+    $this->setEntityTypes(['node']);
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('Invalid entity type.');
+    $this->getSut()->getRevisions('node', '1');
+  }
+
+  /**
+   * Tests whether the entity type is supported or not.
+   */
+  public function testEntityTypeIsSupported() : void {
+    $this->assertFalse($this->getSut()->entityTypeIsSupported('remote_entity_test'));
+    $this->setEntityTypes(['remote_entity_test']);
+    $this->assertTrue($this->getSut()->entityTypeIsSupported('remote_entity_test'));
+  }
+
+  /**
+   * Tests revision deletion.
+   */
+  public function testRevision() : void {
+    $this->setEntityTypes(['remote_entity_test']);
+    /** @var \Drupal\Core\Entity\ContentEntityStorageInterface $storage */
+    $storage = $this->entityTypeManager->getStorage('remote_entity_test');
+    /** @var \Drupal\remote_entity_test\Entity\RemoteEntityTest $entity */
+    $entity = $storage->create(['name' => 'test en', 'id' => 1]);
+    $entity->save();
+
+    $entity->addTranslation('fi', ['name' => 'test fi'])
+      ->addTranslation('sv', ['name' => 'test sv'])
+      ->save();
+
+    for ($i = 0; $i < 10; $i++) {
+      $rmt = $storage->load($entity->id());
+      $rmt->set('name', 'test en ' . $i);
+
+      $rmt->getTranslation('fi')
+        ->set('name', 'name fi ' . $i);
+
+      // Skip one revision to make sure only affected translations are tracked.
+      if ($i > 0) {
+        $rmt->getTranslation('sv')
+          ->set('name', 'name sv ' . $i);
+      }
+
+      $storage->createRevision($rmt)->save();
+    }
+    $revisions = $this->getSut()->getRevisionsPerLanguage('remote_entity_test', $entity->id());
+
+    // We have $i + 1 revisions (11) in total, except sv, which has 10 because
+    // we skipped one revision on purpose.
+    foreach (['en' => 6, 'fi' => 6, 'sv' => 5] as $langcode => $expected) {
+      $this->assertCount($expected, $revisions[$langcode]);
+    }
+    $this->assertCount(6, $this->getSut()->getRevisions('remote_entity_test', $entity->id()));
+
+    // Make sure no revisions are returned when $keep exceeds the number of
+    // total revisions.
+    $revisions = $this->getSut()->getRevisionsPerLanguage('remote_entity_test', $entity->id(), 10);
+    $this->assertCount(0, $revisions['sv']);
+
+    // Delete previous revisions and make sure there are still 5 remaining
+    // for each language.
+    $this->getSut()->deleteRevisions('remote_entity_test', $this->getSut()->getRevisions('remote_entity_test', $entity->id()));
+
+    $revisions = $this->getSut()->getRevisionsPerLanguage('remote_entity_test', $entity->id(), 0);
+
+    foreach (['en' => 5, 'fi' => 5, 'sv' => 5] as $langcode => $expected) {
+      $this->assertCount($expected, $revisions[$langcode]);
+    }
+    $this->assertCount(5, $this->getSut()->getRevisions('remote_entity_test', $entity->id(), 0));
+  }
+
+}

--- a/tests/src/Kernel/Entity/Revision/RevisionManagerTest.php
+++ b/tests/src/Kernel/Entity/Revision/RevisionManagerTest.php
@@ -118,6 +118,8 @@ class RevisionManagerTest extends ApiKernelTestBase {
       ->addTranslation('sv', ['name' => 'test sv'])
       ->save();
 
+    $this->assertCount(0, $this->getSut()->getRevisions('remote_entity_test', $entity->id()));
+
     for ($i = 0; $i < 10; $i++) {
       $rmt = $storage->load($entity->id());
       $rmt->set('name', 'test en ' . $i);

--- a/tests/src/Unit/Commands/RevisionCommandsTest.php
+++ b/tests/src/Unit/Commands/RevisionCommandsTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * Tests revision commands.
  *
+ * @coversDefaultClass \Drupal\helfi_api_base\Commands\RevisionCommands
  * @group helfi_api_base
  */
 class RevisionCommandsTest extends UnitTestCase {
@@ -105,6 +106,9 @@ class RevisionCommandsTest extends UnitTestCase {
 
   /**
    * Test command with invalid entity type.
+   *
+   * @covers ::__construct
+   * @covers ::delete
    */
   public function testInvalidEntityType() : void {
     $io = $this->prophesize(SymfonyStyle::class);
@@ -121,6 +125,9 @@ class RevisionCommandsTest extends UnitTestCase {
 
   /**
    * Test delete without any entities.
+   *
+   * @covers ::__construct
+   * @covers ::delete
    */
   public function testNoEntities() : void {
     $io = $this->prophesize(SymfonyStyle::class);
@@ -138,6 +145,9 @@ class RevisionCommandsTest extends UnitTestCase {
 
   /**
    * Tests delete method with proper data.
+   *
+   * @covers ::__construct
+   * @covers ::delete
    */
   public function testDelete() : void {
     $io = $this->prophesize(SymfonyStyle::class);

--- a/tests/src/Unit/Commands/RevisionCommandsTest.php
+++ b/tests/src/Unit/Commands/RevisionCommandsTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_api_base\Unit\Commands;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Database\Query\Select;
+use Drupal\Core\Database\StatementInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\helfi_api_base\Commands\RevisionCommands;
+use Drupal\helfi_api_base\Entity\Revision\RevisionManager;
+use Drupal\Tests\UnitTestCase;
+use Drush\Commands\DrushCommands;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Tests revision commands.
+ *
+ * @group helfi_api_base
+ */
+class RevisionCommandsTest extends UnitTestCase {
+
+  use ProphecyTrait;
+
+  /**
+   * Gets the SUT.
+   *
+   * @param \Drupal\helfi_api_base\Entity\Revision\RevisionManager $revisionManager
+   *   The revision manager.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface|null $entityTypeManager
+   *   The entity type manager.
+   * @param \Drupal\Core\Database\Connection|null $connection
+   *   The connection.
+   * @param \Prophecy\Prophecy\ObjectProphecy|null $io
+   *   The IO prophecy.
+   *
+   * @return \Drupal\helfi_api_base\Commands\RevisionCommands
+   *   The SUT.
+   */
+  private function getSut(
+    RevisionManager $revisionManager,
+    EntityTypeManagerInterface $entityTypeManager = NULL,
+    Connection $connection = NULL,
+    ObjectProphecy $io = NULL,
+  ) : RevisionCommands {
+    if (!$entityTypeManager) {
+      $definition = $this->prophesize(EntityTypeInterface::class);
+      $definition->getBaseTable()
+        ->willReturn('base_table');
+      $definition->getKey('id')
+        ->willReturn('id');
+      $entityTypeManager = $this->prophesize(EntityTypeManagerInterface::class);
+      $entityTypeManager->getDefinition('node')
+        ->willReturn($definition->reveal());
+      $entityTypeManager = $entityTypeManager->reveal();
+    }
+    if (!$connection) {
+      $connection = $this->prophesize(Connection::class)->reveal();
+    }
+    $sut = new RevisionCommands($revisionManager, $entityTypeManager, $connection);
+
+    if ($io) {
+      $output = $this->prophesize(OutputInterface::class);
+      $input = $this->prophesize(InputInterface::class);
+      $sut->restoreState($input->reveal(), $output->reveal(), $io->reveal());
+    }
+    return $sut;
+  }
+
+  /**
+   * Mocks the connection object.
+   *
+   * @param array $expected
+   *   The expected return value.
+   *
+   * @return \Drupal\Core\Database\Connection
+   *   The connection mock.
+   */
+  private function getConnectionMock(array $expected) : Connection {
+    $statement = $this->prophesize(StatementInterface::class);
+
+    $statement->fetchCol(Argument::any())
+      ->willReturn($expected);
+
+    $select = $this->prophesize(Select::class);
+    $select->fields('t', Argument::any())
+      ->willReturn($select->reveal());
+
+    $select->execute()
+      ->willReturn($statement);
+
+    $database = $this->prophesize(Connection::class);
+    $database->select(Argument::any(), 't')
+      ->willReturn($select);
+
+    return $database->reveal();
+  }
+
+  /**
+   * Test command with invalid entity type.
+   */
+  public function testInvalidEntityType() : void {
+    $io = $this->prophesize(SymfonyStyle::class);
+    $io->writeln(Argument::containingString('Given entity type is not supported.'))
+      ->shouldBeCalled();
+
+    $revisionManager = $this->prophesize(RevisionManager::class);
+    $revisionManager->entityTypeIsSupported('node')->willReturn(FALSE);
+
+    $sut = $this->getSut($revisionManager->reveal(), io: $io);
+
+    $this->assertEquals(DrushCommands::EXIT_SUCCESS, $sut->delete('node'));
+  }
+
+  /**
+   * Test delete without any entities.
+   */
+  public function testNoEntities() : void {
+    $io = $this->prophesize(SymfonyStyle::class);
+    $io->writeln(Argument::containingString('Found 0 node entities'))
+      ->shouldBeCalled();
+
+    $revisionManager = $this->prophesize(RevisionManager::class);
+    $revisionManager->entityTypeIsSupported('node')->willReturn(TRUE);
+    $database = $this->getConnectionMock([]);
+
+    $sut = $this->getSut($revisionManager->reveal(), connection: $database, io: $io);
+
+    $this->assertEquals(DrushCommands::EXIT_SUCCESS, $sut->delete('node'));
+  }
+
+  /**
+   * Tests delete method with proper data.
+   */
+  public function testDelete() : void {
+    $io = $this->prophesize(SymfonyStyle::class);
+    $io->writeln(Argument::containingString('Found 2 node entities'))
+      ->shouldBeCalled();
+    $io->writeln(Argument::containingString('[2/2] Entity has less than 5 revisions. Skipping ...'))
+      ->shouldBeCalled();
+    $io->writeln(Argument::containingString('[1/2] Deleting 6 revisions ...'))
+      ->shouldBeCalled();
+
+    $revisionManager = $this->prophesize(RevisionManager::class);
+    $revisionManager->entityTypeIsSupported('node')->willReturn(TRUE);
+    $revisionManager->getRevisions('node', Argument::any(), Argument::any())
+      ->willReturn([], [1, 2, 3, 4, 5, 6]);
+    $revisionManager->deleteRevisions('node', Argument::any())
+      ->shouldBeCalledTimes(2);
+    $database = $this->getConnectionMock([1, 2]);
+
+    $sut = $this->getSut($revisionManager->reveal(), connection: $database, io: $io);
+
+    $this->assertEquals(DrushCommands::EXIT_SUCCESS, $sut->delete('node'));
+  }
+
+}

--- a/tests/src/Unit/Plugin/QueueWorker/RevisionQueueTest.php
+++ b/tests/src/Unit/Plugin/QueueWorker/RevisionQueueTest.php
@@ -14,6 +14,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
 /**
  * Tests revision queue.
  *
+ * @coversDefaultClass \Drupal\helfi_api_base\Plugin\QueueWorker\RevisionQueue
  * @group helfi_api_base
  */
 class RevisionQueueTest extends UnitTestCase {
@@ -37,6 +38,9 @@ class RevisionQueueTest extends UnitTestCase {
 
   /**
    * Tests that nothing is done for invalid items.
+   *
+   * @covers ::create
+   * @covers ::processItem
    */
   public function testQueueInvalidItem() : void {
     $revisionManager = $this->prophesize(RevisionManager::class);
@@ -48,6 +52,9 @@ class RevisionQueueTest extends UnitTestCase {
 
   /**
    * Make sure nothing is done when an entity does not exist.
+   *
+   * @covers ::create
+   * @covers ::processItem
    */
   public function testNoRevisions() : void {
     $revisionManager = $this->prophesize(RevisionManager::class);
@@ -64,7 +71,10 @@ class RevisionQueueTest extends UnitTestCase {
   }
 
   /**
-   * Make sure revisions are be processed.
+   * Make sure revisions are processed.
+   *
+   * @covers ::create
+   * @covers ::processItem
    */
   public function testDelete() : void {
     $revisionManager = $this->prophesize(RevisionManager::class);

--- a/tests/src/Unit/Plugin/QueueWorker/RevisionQueueTest.php
+++ b/tests/src/Unit/Plugin/QueueWorker/RevisionQueueTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_api_base\Unit;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\helfi_api_base\Entity\Revision\RevisionManager;
+use Drupal\helfi_api_base\Plugin\QueueWorker\RevisionQueue;
+use Drupal\Tests\UnitTestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+/**
+ * Tests revision queue.
+ *
+ * @group helfi_api_base
+ */
+class RevisionQueueTest extends UnitTestCase {
+
+  use ProphecyTrait;
+
+  /**
+   * Gets the SUT.
+   *
+   * @param \Drupal\helfi_api_base\Entity\Revision\RevisionManager $revisionManager
+   *   The revision manager.
+   *
+   * @return \Drupal\helfi_api_base\Plugin\QueueWorker\RevisionQueue
+   *   The revision queue.
+   */
+  private function getSut(RevisionManager $revisionManager) : RevisionQueue {
+    $container = new ContainerBuilder();
+    $container->set('helfi_api_base.revision_manager', $revisionManager);
+    return RevisionQueue::create($container, [], '', []);
+  }
+
+  /**
+   * Tests that nothing is done for invalid items.
+   */
+  public function testQueueInvalidItem() : void {
+    $revisionManager = $this->prophesize(RevisionManager::class);
+    $revisionManager->getRevisions(Argument::any(), Argument::any())
+      ->shouldNotBeCalled();
+
+    $this->getSut($revisionManager->reveal())->processItem([]);
+  }
+
+  /**
+   * Make sure nothing is done when an entity does not exist.
+   */
+  public function testNoRevisions() : void {
+    $revisionManager = $this->prophesize(RevisionManager::class);
+    $revisionManager->deleteRevisions(Argument::any(), Argument::any())
+      ->shouldNotBeCalled();
+    $revisionManager->getRevisions('node', 1)
+      ->shouldBeCalled()
+      ->willReturn([]);
+
+    $this->getSut($revisionManager->reveal())->processItem([
+      'entity_type' => 'node',
+      'entity_id' => 1,
+    ]);
+  }
+
+  /**
+   * Make sure revisions are be processed.
+   */
+  public function testDelete() : void {
+    $revisionManager = $this->prophesize(RevisionManager::class);
+    $revisionManager->deleteRevisions('node', [1, 2, 3])
+      ->shouldBeCalled();
+    $revisionManager->getRevisions('node', 1)
+      ->shouldBeCalled()
+      ->willReturn([1, 2, 3]);
+
+    $this->getSut($revisionManager->reveal())->processItem([
+      'entity_type' => 'node',
+      'entity_id' => 1,
+    ]);
+  }
+
+}


### PR DESCRIPTION
## How to install

- `composer require drupal/helfi_api_base:dev-UHF-7324`
- `drush cr`
- Add this to your `local.settings.php` file:
```php
$config['helfi_api_base.delete_revisions']['entity_types'] = [
  'node',
  'paragraph',
  'tpr_unit',
  'tpr_service',
  'tpr_errand_service',
];
```

## How to test

* [x] Find a node with more than 5 revisions (https://helfi-kymp.docker.so/fi/kaupunkiymparisto-ja-liikenne/kaupunkisuunnittelu-ja-rakentaminen on Liikenne for example)
* [x] Make sure `Create new revision` checkbox is checked, make some changes and save the node
* [x] Run `drush cron` and make sure the node has 5 revisions for each translation
* [x] Run `drush helfi:revision:delete node` and make sure old revisions are deleted