### PR TITLE
UHF-8255: Remove email from contact section that is no longer used

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,3 @@ A base module for [drupal-helfi-platform](https://github.com/City-of-Helsinki/dr
 ## Contact
 
 Slack: #helfi-drupal (http://helsinkicity.slack.com/)
-
-Mail: `drupal@hel.fi`


### PR DESCRIPTION
Check the README that the email drupal@hel.fi is no longer in there.