### PR TITLE
UHF-9113: Drupal 10 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "firebase/php-jwt": "^6.5",
         "php": "^8.1",
         "t4web/composer-lock-parser": "^1.0",
-        "textalk/websocket": "^1.6"
+        "textalk/websocket": "^1.6",
+        "webmozart/assert": "^1.0"
     },
     "conflict": {
         "drupal/helfi_debug": "*"


### PR DESCRIPTION
# [UHF-9113](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9113)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Azure pipeline fails to deploy Drupal 10 update. This attempts to fix the crash:
```
Error: Class "Webmozart\Assert\Assert" not found in /var/www/html/public/modules/contrib/helfi_api_base/src/Vault/VaultManager.php on line 30 #0 /var/www/html/public/modules/contrib/helfi_api_base/src/Vault/VaultManagerFactory.php(46): Drupal\helfi_api_base\Vault\VaultManager->__construct()
```

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that composer.json has no typos.


[UHF-9113]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ