### PR TITLE
UHF-10063 unkown function error

### DIFF
--- a/drush.services.yml
+++ b/drush.services.yml
@@ -36,3 +36,11 @@ services:
       - '@database'
     tags:
       - { name: drush.command }
+  helfi_api_base.helfi_twig_commands:
+    class: \Drupal\helfi_api_base\Commands\HelfiTwigCommands
+    arguments:
+      - '@twig'
+      - '@module_handler'
+      - '@extension.list.module'
+    tags:
+      - { name: drush.command }

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -38,6 +38,6 @@ services:
       - { name: drush.command }
   helfi_api_base.helfi_twig_commands:
     class: \Drupal\helfi_api_base\Commands\HelfiTwigCommands
-    arguments: ['@twig', '@module_handler', '@extension.list.module']
+    arguments: ['@twig', '@module_handler', '@theme_handler','@extension.list.module']
     tags:
       - { name: drush.command }

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -38,9 +38,6 @@ services:
       - { name: drush.command }
   helfi_api_base.helfi_twig_commands:
     class: \Drupal\helfi_api_base\Commands\HelfiTwigCommands
-    arguments:
-      - '@twig'
-      - '@module_handler'
-      - '@extension.list.module'
+    arguments: ['@twig', '@module_handler', '@extension.list.module']
     tags:
       - { name: drush.command }

--- a/src/Commands/HelfiTwigCommands.php
+++ b/src/Commands/HelfiTwigCommands.php
@@ -26,17 +26,6 @@ final class HelfiTwigCommands extends DrushCommands {
   ) {
   }
 
-  public static function create(ContainerInterface $container): self
-  {
-    $commandHandler = new static(
-      $container->get('twig'),
-      $container->get('module_handler'),
-      $container->get('extension.list.module'),
-    );
-
-    return $commandHandler;
-  }
-
   public function getTwig(): TwigEnvironment {
     return $this->twig;
   }

--- a/src/Commands/HelfiTwigCommands.php
+++ b/src/Commands/HelfiTwigCommands.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drush\Commands\core;
+
+use Drupal\Core\Extension\ExtensionList;
+use Drupal\Core\Template\TwigEnvironment;
+use Drush\Attributes\Command;
+use Drush\Commands\DrushCommands;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drush\Drush;
+use Symfony\Component\Filesystem\Path;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Drush command to compile twig.
+ */
+final class HelfiTwigCommands extends DrushCommands {
+
+  public function __construct(
+    protected TwigEnvironment $twig,
+    protected ModuleHandlerInterface $moduleHandler,
+    readonly private ExtensionList $extensionList,
+  ) {
+  }
+
+  public static function create(ContainerInterface $container): self
+  {
+    $commandHandler = new static(
+      $container->get('twig'),
+      $container->get('module_handler'),
+      $container->get('extension.list.module'),
+    );
+
+    return $commandHandler;
+  }
+
+  public function getTwig(): TwigEnvironment {
+    return $this->twig;
+  }
+
+  public function getModuleHandler(): ModuleHandlerInterface {
+    return $this->moduleHandler;
+  }
+
+  /**
+   * Compile all Twig template(s).
+   */
+  #[Command(name: 'helfi:twig:compile')]
+  public function helfiTwigCompile(): void {
+    require_once DRUSH_DRUPAL_CORE . "/themes/engines/twig/twig.engine";
+    // Scan all enabled modules and themes.
+    $modules = array_keys($this->getModuleHandler()->getModuleList());
+    foreach ($modules as $module) {
+      $searchpaths[] = $this->extensionList->getPath($module);
+    }
+
+    $themes = \Drupal::service('theme_handler')->listInfo();
+    foreach ($themes as $name => $theme) {
+      $searchpaths[] = $theme->getPath();
+    }
+
+    // Prevent processing help_topics if the module not enabled.
+    $excludes = $this->getModuleHandler()
+      ->moduleExists('help_topics') ? 'tests' : ['tests', 'help_topics'];
+
+    $files = Finder::create()
+      ->files()
+      ->name('*.html.twig')
+      ->exclude($excludes)
+      ->in($searchpaths);
+    foreach ($files as $file) {
+      $relative = Path::makeRelative($file->getRealPath(), Drush::bootstrapManager()->getRoot());
+      // Loading the template ensures the compiled template is cached.
+      $this->getTwig()->load($relative);
+      $this->logger()->success(dt('Compiled twig template !path', ['!path' => $relative]));
+    }
+  }
+
+}

--- a/src/Commands/HelfiTwigCommands.php
+++ b/src/Commands/HelfiTwigCommands.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Drush\Commands\core;
+namespace Drupal\helfi_api_base\Commands;
 
 use Drupal\Core\Extension\ExtensionList;
 use Drupal\Core\Template\TwigEnvironment;
@@ -12,7 +12,6 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drush\Drush;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Drush command to compile twig.

--- a/src/Commands/HelfiTwigCommands.php
+++ b/src/Commands/HelfiTwigCommands.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Drupal\helfi_api_base\Commands;
 
 use Drupal\Core\Extension\ExtensionList;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Extension\ThemeHandlerInterface;
 use Drupal\Core\Template\TwigEnvironment;
 use Drush\Attributes\Command;
 use Drush\Commands\DrushCommands;
-use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drush\Drush;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
@@ -21,40 +22,33 @@ final class HelfiTwigCommands extends DrushCommands {
   public function __construct(
     protected TwigEnvironment $twig,
     protected ModuleHandlerInterface $moduleHandler,
+    protected ThemeHandlerInterface $themeHandler,
     readonly private ExtensionList $extensionList,
   ) {
   }
 
-  public function getTwig(): TwigEnvironment {
-    return $this->twig;
-  }
-
-  public function getModuleHandler(): ModuleHandlerInterface {
-    return $this->moduleHandler;
-  }
-
   /**
    * Compile all Twig template(s).
-   * UHF-10063 prevent unknown function -error caused by
-   * twig files in core modules' help_topics folders
    *
+   * UHF-10063 prevent unknown function -error caused by
+   * twig files in core modules' help_topics folders.
    */
   #[Command(name: 'helfi:twig:compile')]
   public function helfiTwigCompile(): void {
     require_once DRUSH_DRUPAL_CORE . "/themes/engines/twig/twig.engine";
     // Scan all enabled modules and themes.
-    $modules = array_keys($this->getModuleHandler()->getModuleList());
+    $modules = array_keys($this->moduleHandler->getModuleList());
     foreach ($modules as $module) {
       $searchpaths[] = $this->extensionList->getPath($module);
     }
 
-    $themes = \Drupal::service('theme_handler')->listInfo();
-    foreach ($themes as $name => $theme) {
+    $themes = $this->themeHandler->listInfo();
+    foreach ($themes as $theme) {
       $searchpaths[] = $theme->getPath();
     }
 
     // Prevent processing help_topics if the module not enabled.
-    $excludes = $this->getModuleHandler()
+    $excludes = $this->moduleHandler
       ->moduleExists('help_topics') ? 'tests' : ['tests', 'help_topics'];
 
     $files = Finder::create()
@@ -65,7 +59,7 @@ final class HelfiTwigCommands extends DrushCommands {
     foreach ($files as $file) {
       $relative = Path::makeRelative($file->getRealPath(), Drush::bootstrapManager()->getRoot());
       // Loading the template ensures the compiled template is cached.
-      $this->getTwig()->load($relative);
+      $this->twig->load($relative);
       $this->logger()->success(dt('Compiled twig template !path', ['!path' => $relative]));
     }
   }

--- a/src/Commands/HelfiTwigCommands.php
+++ b/src/Commands/HelfiTwigCommands.php
@@ -35,6 +35,9 @@ final class HelfiTwigCommands extends DrushCommands {
 
   /**
    * Compile all Twig template(s).
+   * UHF-10063 prevent unknown function -error caused by
+   * twig files in core modules' help_topics folders
+   *
    */
   #[Command(name: 'helfi:twig:compile')]
   public function helfiTwigCompile(): void {


### PR DESCRIPTION
# [UHF-10063](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10063)
Fixes 'Unknown "help_route_link" function' -error by enabling help_topic module

## What was done
Created helfi:twig:compile command to be used instead of twig:compile.

## How to reproduce
- Setup any project
- Run drush twig:compile
You'll see error

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout dev`
  * `make fresh`
* Run `composer require drupal/helfi_api_base:dev-UHF-10063` 
* Run `make drush-cr`

## How to test
- Run drush helfi:twig:compile
There is no error 



[UHF-10063]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ