### PR TITLE
UHF-9708: Add type argument to getCurrentOrFallbackLanguage

### DIFF
--- a/src/Language/DefaultLanguageResolver.php
+++ b/src/Language/DefaultLanguageResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\helfi_api_base\Language;
 
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
@@ -78,11 +79,14 @@ final class DefaultLanguageResolver {
   /**
    * Get current or fallback langcode.
    *
+   * @param string $type
+   *   (optional) The language type.
+   *
    * @return string
    *   Current or fallback language ID if current doesn't have full support.
    */
-  public function getCurrentOrFallbackLanguage(): string {
-    $langcode = $this->languageManager->getCurrentLanguage()->getId();
+  public function getCurrentOrFallbackLanguage(string $type = LanguageInterface::TYPE_INTERFACE): string {
+    $langcode = $this->languageManager->getCurrentLanguage($type)->getId();
     if ($this->isAltLanguage($langcode)) {
       return $this->getFallbackLanguage();
     }


### PR DESCRIPTION
# [UHF-9708](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9708)
<!-- What problem does this solve? -->

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/773

[UHF-9708]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ