### PR TITLE
UHF-9367: Allow exceptions for setupMockHttpClient()

### DIFF
--- a/tests/src/Traits/ApiTestTrait.php
+++ b/tests/src/Traits/ApiTestTrait.php
@@ -45,7 +45,7 @@ trait ApiTestTrait {
   /**
    * Overrides the default 'http_client_factory' service with mock.
    *
-   * @param \Psr\Http\Message\ResponseInterface[] $responses
+   * @param \Psr\Http\Message\ResponseInterface[]|\GuzzleHttp\Exception\GuzzleException[] $responses
    *   The expected responses.
    *
    * @return \GuzzleHttp\Client


### PR DESCRIPTION
# [UHF-9367](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9367)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Allow exceptions for setupMockHttpClient().

[UHF-9367]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ