### PR TITLE
UHF-10844 & UHF-10842: Add raven monolog logger

### DIFF
--- a/src/HelfiApiBaseServiceProvider.php
+++ b/src/HelfiApiBaseServiceProvider.php
@@ -37,6 +37,10 @@ final class HelfiApiBaseServiceProvider extends ServiceProviderBase {
               'name' => 'default_conditional_handler',
               'formatter' => 'drush_or_json',
             ],
+            [
+              'name' => 'drupal.raven',
+              'processors' => ['current_user', 'request_uri', 'ip', 'referer'],
+            ],
           ],
         ],
       ]);

--- a/tests/src/Unit/Commands/PubSubCommandsTest.php
+++ b/tests/src/Unit/Commands/PubSubCommandsTest.php
@@ -8,11 +8,11 @@ use Drupal\Tests\UnitTestCase;
 use Drupal\helfi_api_base\Azure\PubSub\PubSubManagerInterface;
 use Drupal\helfi_api_base\Drush\Commands\PubSubCommands;
 use Drush\Commands\DrushCommands;
+use Drush\Style\DrushStyle;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use WebSocket\ConnectionException;
 use WebSocket\TimeoutException;
 
@@ -31,7 +31,7 @@ class PubSubCommandsTest extends UnitTestCase {
     $expectedMessage = '{"message":"test"}';
     $output = $this->prophesize(OutputInterface::class);
     $input = $this->prophesize(InputInterface::class);
-    $io = $this->prophesize(SymfonyStyle::class);
+    $io = $this->prophesize(DrushStyle::class);
     $io->writeln(Argument::containingString('Received message'))
       ->shouldBeCalledTimes(PubSubCommands::MAX_MESSAGES);
     $io->writeln(Argument::containingString('Received maximum number of messages'))
@@ -51,7 +51,7 @@ class PubSubCommandsTest extends UnitTestCase {
   public function testExceptionOutput() : void {
     $output = $this->prophesize(OutputInterface::class);
     $input = $this->prophesize(InputInterface::class);
-    $io = $this->prophesize(SymfonyStyle::class);
+    $io = $this->prophesize(DrushStyle::class);
     $io->writeln('Invalid json: Syntax error')->shouldBeCalledTimes(PubSubCommands::MAX_MESSAGES);
     $io->writeln(Argument::containingString('Received maximum number of messages'))
       ->shouldBeCalledTimes(1);
@@ -70,7 +70,7 @@ class PubSubCommandsTest extends UnitTestCase {
   public function testTimeoutException() : void {
     $output = $this->prophesize(OutputInterface::class);
     $input = $this->prophesize(InputInterface::class);
-    $io = $this->prophesize(SymfonyStyle::class);
+    $io = $this->prophesize(DrushStyle::class);
     $io->writeln(Argument::containingString('Received maximum number of messages'))
       ->shouldBeCalledTimes(1);
 

--- a/tests/src/Unit/Commands/RevisionCommandsTest.php
+++ b/tests/src/Unit/Commands/RevisionCommandsTest.php
@@ -13,12 +13,12 @@ use Drupal\Tests\UnitTestCase;
 use Drupal\helfi_api_base\Commands\RevisionCommands;
 use Drupal\helfi_api_base\Entity\Revision\RevisionManager;
 use Drush\Commands\DrushCommands;
+use Drush\Style\DrushStyle;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Tests revision commands.
@@ -114,7 +114,7 @@ class RevisionCommandsTest extends UnitTestCase {
    * Test command with invalid entity type.
    */
   public function testInvalidEntityType() : void {
-    $io = $this->prophesize(SymfonyStyle::class);
+    $io = $this->prophesize(DrushStyle::class);
     $io->writeln(Argument::containingString('Given entity type is not supported.'))
       ->shouldBeCalled();
 
@@ -130,7 +130,7 @@ class RevisionCommandsTest extends UnitTestCase {
    * Test delete without any entities.
    */
   public function testNoEntities() : void {
-    $io = $this->prophesize(SymfonyStyle::class);
+    $io = $this->prophesize(DrushStyle::class);
     $io->isDecorated()
       ->willReturn(TRUE);
     $io->getVerbosity()
@@ -148,7 +148,7 @@ class RevisionCommandsTest extends UnitTestCase {
    * Tests delete method with proper data.
    */
   public function testDelete() : void {
-    $io = $this->prophesize(SymfonyStyle::class);
+    $io = $this->prophesize(DrushStyle::class);
     $io->isDecorated()
       ->willReturn(TRUE);
     $io->getVerbosity()
@@ -170,7 +170,7 @@ class RevisionCommandsTest extends UnitTestCase {
    * Tests delete method with optional ID.
    */
   public function testDeleteWithId() : void {
-    $io = $this->prophesize(SymfonyStyle::class);
+    $io = $this->prophesize(DrushStyle::class);
     $io->isDecorated()
       ->willReturn(TRUE);
     $io->getVerbosity()


### PR DESCRIPTION
# [UHF-10844](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10844)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add raven monolog handler: https://git.drupalcode.org/project/raven\#monolog-module-integration.

## How to install

* Add Sentry environment variables to `compose.yaml`
* Make sure your instance is up and running on correct branch.
  * `composer require drupal/helfi_api_base:dev-UHF-10844-sentry-logging`
  * `make fresh`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR

## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-10844]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ