### PR TITLE
UHF-10944: Add sentry logger back

### DIFF
--- a/src/HelfiApiBaseServiceProvider.php
+++ b/src/HelfiApiBaseServiceProvider.php
@@ -34,6 +34,12 @@ final class HelfiApiBaseServiceProvider extends ServiceProviderBase {
         'default' => [
           'handlers' => [
             [
+              // The Raven logger handler must be added to forward log messages
+              // to Sentry. We remove the `message_placeholder` processor from
+              // the default processors, as Raven already handles placeholders.
+              // NOTE: The `filter_backtrace` processor should be included.
+              // Without it, logging long backtraces may lead to out-of-memory
+              // errors.
               'name' => 'drupal.raven',
               'processors' => [
                 'current_user',

--- a/src/HelfiApiBaseServiceProvider.php
+++ b/src/HelfiApiBaseServiceProvider.php
@@ -34,6 +34,16 @@ final class HelfiApiBaseServiceProvider extends ServiceProviderBase {
         'default' => [
           'handlers' => [
             [
+              'name' => 'drupal.raven',
+              'processors' => [
+                'current_user',
+                'request_uri',
+                'ip',
+                'referer',
+                'filter_backtrace',
+              ],
+            ],
+            [
               'name' => 'default_conditional_handler',
               'formatter' => 'drush_or_json',
             ],


### PR DESCRIPTION
# [UHF-10944](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10944)
<!-- What problem does this solve? -->

Raven [README.md](https://git.drupalcode.org/project/raven/-/blob/6.x/README.md?ref_type=heads) asks to disable `message_placeholder` and `filter_backtrace` processors. However, these cause Monolog Lineformatter::format to consume excessive memory when processing log messages with long stack traces.

Adding these back don't seem to cause any problems, and the processors seem to drastically reduce logger memory usage.


## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/pull/186

[UHF-10944]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ