### PR TITLE
Add elasticsearch connector plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,8 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "dg/bypass-finals": "^1.0",
         "drupal/coder": "^8.3",
+        "drupal/search_api": "^1.0",
+        "drupal/elasticsearch_connector": "^8.0@alpha",
         "donatj/mock-webserver": "dev-master"
     }
 }

--- a/config/schema/elasticsearch_connector.connector.helfi_connector.schema.yml
+++ b/config/schema/elasticsearch_connector.connector.helfi_connector.schema.yml
@@ -1,0 +1,2 @@
+plugin.plugin_configuration.elasticsearch_connector.helfi_connector:
+  type: plugin.plugin_configuration.elasticsearch_connector.basicauth

--- a/src/Plugin/ElasticSearch/Connector/HelfiConnector.php
+++ b/src/Plugin/ElasticSearch/Connector/HelfiConnector.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_api_base\Plugin\ElasticSearch\Connector;
+
+use Drupal\elasticsearch_connector\Plugin\ElasticSearch\Connector\BasicAuthConnector;
+use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\ClientBuilder;
+
+/**
+ * Provides an ElasticSearch connector that accepts self-signed certificates.
+ *
+ * @ElasticSearchConnector(
+ *   id = "helfi_connector",
+ *   label = @Translation("Helfi Connector"),
+ *   description = @Translation("ElasticSearch connector with HTTP Basic Auth that accepts self signed certificates.")
+ * )
+ */
+class HelfiConnector extends BasicAuthConnector {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getClient(): Client {
+    return ClientBuilder::create()
+      ->setHosts([$this->configuration['url']])
+      ->setBasicAuthentication($this->configuration['username'], $this->configuration['password'])
+      ->setSSLVerification(FALSE)
+      ->build();
+  }
+
+}

--- a/tests/src/Functional/ElasticsearchConnectorTest.php
+++ b/tests/src/Functional/ElasticsearchConnectorTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_api_base\Functional;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Url;
+use Drupal\elasticsearch_connector\Plugin\search_api\backend\ElasticSearchBackend;
+use Drupal\helfi_api_base\Plugin\ElasticSearch\Connector\HelfiConnector;
+
+/**
+ * Test for elasticsearch connector plugin.
+ */
+class ElasticsearchConnectorTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'search_api',
+    'elasticsearch_connector',
+    'helfi_api_base',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp(): void {
+    parent::setUp();
+
+    // Create an admin user.
+    $admin_user = $this->drupalCreateUser([
+      'access administration pages',
+      'administer search_api',
+    ]);
+    $this->drupalLogin($admin_user);
+  }
+
+  /**
+   * Tests custom elasticsearch connector.
+   */
+  public function testSearchApiConnector() {
+    // Add elasticsearch server configuration.
+    $config = $this->config('search_api.server.default');
+    $config->setData([
+      'status' => TRUE,
+      'id' => 'default',
+      'name' => 'elasticsearch_server',
+      'description' => 'Test server',
+      'backend' => 'elasticsearch',
+      'backend_config' => [
+        'connector' => 'helfi_connector',
+        'connector_config' => [
+          'url' => 'http://elasticsearch.example.com:9200',
+          'username' => '123',
+          'password' => '456',
+        ],
+      ],
+    ]);
+    $config->save();
+
+    /** @var \Drupal\search_api\ServerInterface $server */
+    $server = $this->container
+      ->get(EntityTypeManagerInterface::class)
+      ->getStorage('search_api_server')
+      ->load('default');
+
+    $backend = $server->getBackend();
+    assert($backend instanceof ElasticSearchBackend);
+    $this->assertInstanceOf(HelfiConnector::class, $backend->getConnector());
+
+    $assert_session = $this->assertSession();
+    $this->drupalGet(Url::fromRoute('entity.search_api_server.edit_form', [
+      'search_api_server' => 'default',
+    ]));
+    $assert_session->statusCodeEquals(200);
+    $assert_session->pageTextContains('Helfi Connector');
+  }
+
+}

--- a/tests/src/Kernel/ElasticsearchConnectorTest.php
+++ b/tests/src/Kernel/ElasticsearchConnectorTest.php
@@ -2,17 +2,18 @@
 
 declare(strict_types=1);
 
-namespace Drupal\Tests\helfi_api_base\Functional;
+namespace Drupal\Tests\helfi_api_base\Kernel;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Url;
+use Drupal\KernelTests\KernelTestBase;
 use Drupal\elasticsearch_connector\Plugin\search_api\backend\ElasticSearchBackend;
 use Drupal\helfi_api_base\Plugin\ElasticSearch\Connector\HelfiConnector;
+use Elastic\Elasticsearch\Client;
 
 /**
  * Test for elasticsearch connector plugin.
  */
-class ElasticsearchConnectorTest extends BrowserTestBase {
+class ElasticsearchConnectorTest extends KernelTestBase {
 
   /**
    * {@inheritdoc}
@@ -26,20 +27,10 @@ class ElasticsearchConnectorTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected $defaultTheme = 'stark';
-
-  /**
-   * {@inheritdoc}
-   */
   public function setUp(): void {
     parent::setUp();
 
-    // Create an admin user.
-    $admin_user = $this->drupalCreateUser([
-      'access administration pages',
-      'administer search_api',
-    ]);
-    $this->drupalLogin($admin_user);
+    $this->installEntitySchema('search_api_server');
   }
 
   /**
@@ -73,14 +64,9 @@ class ElasticsearchConnectorTest extends BrowserTestBase {
 
     $backend = $server->getBackend();
     assert($backend instanceof ElasticSearchBackend);
-    $this->assertInstanceOf(HelfiConnector::class, $backend->getConnector());
-
-    $assert_session = $this->assertSession();
-    $this->drupalGet(Url::fromRoute('entity.search_api_server.edit_form', [
-      'search_api_server' => 'default',
-    ]));
-    $assert_session->statusCodeEquals(200);
-    $assert_session->pageTextContains('Helfi Connector');
+    $connector = $backend->getConnector();
+    $this->assertInstanceOf(HelfiConnector::class, $connector);
+    $this->assertInstanceOf(Client::class, $connector->getClient());
   }
 
 }


### PR DESCRIPTION
Related to https://helsinkisolutionoffice.atlassian.net/browse/UHF-10549.

Service addresses use self signed sertificate. To use them, we need to configure elasticsearch_connector module such that it accepts these sertificates.

# How to test:

Run: `composer require drupal/helfi_api_base:dev-UHF-10990`.

In infofinland, add 

```
$config['search_api.server.default']['backend_config']['connector'] = 'basicauth';
$config['search_api.server.default']['backend_config']['connector_config']['url'] = 'https://self-signed.badssl.com/';
$config['search_api.server.default']['backend_config']['connector_config']['username'] = '123';
$config['search_api.server.default']['backend_config']['connector_config']['password'] = '456';

```
to `local.settings.php`.

https://drupal-infofinland.docker.so/admin/config/search/search-api/server/default should die to certificate errors.

Change to 

```
$config['search_api.server.default']['backend_config']['connector'] = 'helfi_connector';
$config['search_api.server.default']['backend_config']['connector_config']['url'] = 'https://self-signed.badssl.com/';
$config['search_api.server.default']['backend_config']['connector_config']['username'] = '123';
$config['search_api.server.default']['backend_config']['connector_config']['password'] = '456';

```

https://drupal-infofinland.docker.so/admin/config/search/search-api/server/default should not die. Should give error "The ElasticSearch cluster could not be reached. Further data is therefore unavailable." because 'https://self-signed.badssl.com/' is not elasticsearch server.