### PR TITLE
UHF-10713: Fix update hook if module is not installed of config is missing

### DIFF
--- a/helfi_api_base.install
+++ b/helfi_api_base.install
@@ -343,8 +343,12 @@ function _helfi_api_base_process_links(ContentEntityInterface $entity, string $f
  * UHF-10713 Remove VersionChecker.
  */
 function helfi_api_base_update_9023(): void {
+  if (!\Drupal::moduleHandler()->moduleExists('rest')) {
+    return;
+  }
+
   \Drupal::entityTypeManager()
     ->getStorage('rest_resource_config')
     ->load('helfi_debug_package_version')
-    ->delete();
+    ?->delete();
 }


### PR DESCRIPTION
# [UHF-10713](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10713)
<!-- What problem does this solve? -->

## What was done

Update hooks fails on paatokset: https://github.com/City-of-Helsinki/helsinki-paatokset/actions/runs/12369282693/job/34520859820.

[UHF-10713]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ