### PR TITLE
UHF-11480: Why revision could not be found

### DIFF
--- a/src/Entity/Revision/RevisionManager.php
+++ b/src/Entity/Revision/RevisionManager.php
@@ -174,8 +174,6 @@ class RevisionManager {
       /** @var \Drupal\Core\Entity\TranslatableRevisionableInterface $revision */
       $revision = $storage->loadRevision($vid);
 
-      // @todo Figure out why revision is not found,
-      // @see #UHF-11480.
       if (!$revision) {
         continue;
       }


### PR DESCRIPTION
# [UHF-11480](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11480)

This error was most likely caused by database replacer.


[UHF-11480]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ