### PR TITLE
UHF-11682: Lower log level for PubSub connection failures

### DIFF
--- a/src/Azure/PubSub/PubSubManager.php
+++ b/src/Azure/PubSub/PubSubManager.php
@@ -7,6 +7,7 @@ namespace Drupal\helfi_api_base\Azure\PubSub;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Utility\Error;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use WebSocket\Client;
@@ -75,10 +76,13 @@ final class PubSubManager implements PubSubManagerInterface {
         ]));
       }
       catch (ConnectionException $exception) {
-        Error::logException($this->logger, $exception);
+        Error::logException($this->logger, $exception, level: LogLevel::INFO);
       }
     }
 
+    // Propagate the error if connection fails with all available access keys.
+    // When this is called from the Drush command, this causes the command to
+    // fail with exit code 1.
     if ($exception instanceof ConnectionException) {
       throw $exception;
     }


### PR DESCRIPTION
# [UHF-11682](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11682)
<!-- What problem does this solve? -->

This error seems to happen occasionally when connections fail.

This patch reduces the log level for ConnectionException so these errors are no longer reported to Sentry. INFO messages however are still logged into the server logs.

If all access key checks fail, the `drush helfi:azure:pubsub-listen` command will exit with a non-zero status, causing the cron pod to enter a crash loop. This crash loop can be detected by other means (e.g., a separate Sentry error), so logging the repeated connection exceptions to Sentry is unnecessary.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11682-decrease-log-level`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that code follows our standards

[UHF-11682]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ