### PR TITLE
UHF-10321: Add user login restriction for non-private networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A base module for [drupal-helfi-platform](https://github.com/City-of-Helsinki/dr
 - [Remote Entity](documentation/remote-entity.md): A base entity to be used with migrations.
 - [Testing](documentation/testing.md): Various features to help with automated testing.
 - [User expire / Delete](/documentation/user-expire.md): Block/delete inactive accounts automatically.
+- [User login restriction](/documentation/user-login-restriction.md): Blocks login attempts from non-private networks.
 - [Asset versioning](./documentation/asset-versioning.md): Replace js/css library version with deployment identifier.
 
 ## Contact

--- a/documentation/user-login-restriction.md
+++ b/documentation/user-login-restriction.md
@@ -1,0 +1,19 @@
+# User login restrictions
+
+This feature is used to restrict login attempts to private networks for configure roles. It is implemented with an [event listener](../src/EventSubscriber/UserLoginSubscriber.php).
+
+## Configuration
+
+See `helfi_api_base.restricted_roles` parameter in [helfi_api_base.services.yml](/helfi_api_base.services.yml).
+
+The value can be overridden in one of these files:
+
+```yaml
+# public/sites/default/services.yml
+# public/sites/default/{env}.services.yml
+parameters:
+  helfi_api_base.restricted_roles:
+    - 'some-role-name'
+```
+
+or dynamically in service provider class: https://www.drupal.org/docs/drupal-apis/services-and-dependency-injection/altering-existing-services-providing-dynamic-services.

--- a/helfi_api_base.services.yml
+++ b/helfi_api_base.services.yml
@@ -14,6 +14,7 @@ parameters:
   helfi_api_base.disable_password_users:
     - helfi-admin
     - 1
+  helfi_api_base.restricted_roles: []
 services:
   _defaults:
     autowire: true
@@ -108,6 +109,8 @@ services:
   Drupal\helfi_api_base\Cache\CacheTagInvalidator: ~
 
   Drupal\helfi_api_base\EventSubscriber\CacheTagInvalidatorSubscriber: ~
+
+  Drupal\helfi_api_base\EventSubscriber\UserLoginSubscriber: ~
 
   Drupal\helfi_api_base\Entity\Revision\RevisionManager: '@helfi_api_base.revision_manager'
   helfi_api_base.revision_manager:

--- a/src/EventSubscriber/UserLoginSubscriber.php
+++ b/src/EventSubscriber/UserLoginSubscriber.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_api_base\EventSubscriber;
+
+use Drupal\Core\Session\AccountEvents;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Session\AccountSetEvent;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\IpUtils;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Listens user events.
+ */
+class UserLoginSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Constructs a new instance.
+   */
+  public function __construct(
+    private readonly RequestStack $requestStack,
+    #[Autowire(param: 'helfi_api_base.restricted_roles')]
+    private readonly array $restrictedRoles,
+    #[Autowire(service: 'logger.channel.helfi_api_base')]
+    private readonly LoggerInterface $logger,
+  ) {
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      AccountEvents::SET_USER => 'onUserLogin',
+    ];
+  }
+
+  /**
+   * Reacts to `account.set` event.
+   *
+   * @param \Drupal\Core\Session\AccountSetEvent $event
+   *   The event.
+   */
+  public function onUserLogin(AccountSetEvent $event): void {
+    $account = $event->getAccount();
+
+    if (!$this->applies($account)) {
+      return;
+    }
+
+    $request = $this->requestStack->getCurrentRequest();
+    $clientIp = $request->getClientIp();
+
+    if (!$clientIp || !IpUtils::checkIp($clientIp, IpUtils::PRIVATE_SUBNETS)) {
+      $this->logger->warning('Login attempt denied for @user from @ip.', [
+        '@user' => $account->getAccountName(),
+        '@ip' => $clientIp,
+      ]);
+
+      user_logout();
+    }
+  }
+
+  /**
+   * Returns true if login is restricted for the given account.
+   */
+  private function applies(AccountInterface $account): bool {
+    if ($account->isAnonymous()) {
+      return FALSE;
+    }
+
+    if (array_intersect($account->getRoles(TRUE), $this->restrictedRoles)) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+}

--- a/tests/src/Kernel/EventSubscriber/UserLoginSubscriberTest.php
+++ b/tests/src/Kernel/EventSubscriber/UserLoginSubscriberTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_api_base\Kernel;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Tests user login subscriber.
+ *
+ * @group helfi_api_base
+ */
+class UserLoginSubscriberTest extends KernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * Drupal request stack.
+   */
+  private RequestStack $requestStack;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'helfi_api_base',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+
+    // Store requestStack before tests so
+    // that it can be restored in tearDown().
+    $this->requestStack = $this->container->get('request_stack');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    $this->container->set('request_stack', $this->requestStack);
+
+    parent::tearDown();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container) : void {
+    parent::register($container);
+
+    $container->setParameter('helfi_api_base.restricted_roles', [
+      'test_role',
+    ]);
+  }
+
+  /**
+   * Tests login restrictions.
+   */
+  public function testLoginRestrictions() : void {
+    $requestStack = $this->prophesize(RequestStack::class);
+    $requestStack
+      ->getCurrentRequest()
+      ->willReturn(new Request(server: [
+        'REMOTE_ADDR' => '123.123.123.123',
+      ]));
+
+    $this->container->set('request_stack', $requestStack->reveal());
+
+    $user1 = $this->createUser();
+    $user2 = $this->createUser();
+
+    // Having this role should prevent login from non-private IP ranges.
+    $this->createRole([], name: 'test_role');
+    $user2->addRole('test_role');
+
+    // Login attempt from non-restricted user.
+    $this->setCurrentUser($user1);
+
+    // Verify that logging in succeeded.
+    $current = $this->container->get('current_user');
+    $this->assertInstanceOf(AccountProxyInterface::class, $current);
+    $this->assertFalse($current->isAnonymous());
+
+    // Login attempt from restricted user.
+    $this->setCurrentUser($user2);
+
+    // Verify that logging in fails.
+    $current = $this->container->get('current_user');
+    $this->assertInstanceOf(AccountProxyInterface::class, $current);
+    $this->assertTrue($current->isAnonymous());
+  }
+
+  /**
+   * Tests login from private network.
+   */
+  public function testLoginRestrictionsFromPrivateNetwork() : void {
+    $requestStack = $this->prophesize(RequestStack::class);
+    $requestStack
+      ->getCurrentRequest()
+      ->willReturn(new Request(server: [
+        'REMOTE_ADDR' => '192.168.1.2',
+      ]));
+
+    $this->container->set('request_stack', $requestStack->reveal());
+
+    $user = $this->createUser();
+
+    // Having this role should prevent login from non-private IP ranges.
+    $this->createRole([], name: 'test_role');
+    $user->addRole('test_role');
+
+    // Login attempt from non-restricted user.
+    $this->setCurrentUser($user);
+
+    // Verify that logging in succeeded.
+    $current = $this->container->get('current_user');
+    $this->assertInstanceOf(AccountProxyInterface::class, $current);
+    $this->assertFalse($current->isAnonymous());
+  }
+
+}


### PR DESCRIPTION
# [UHF-10321](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10321)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Implements role-based login restrictions that block login attempts from public IP addresses for configured user roles.

## How to install

* Make sure your etusivu is up and running on correct branch.
  * `git checkout UHF-10321`
  * `composer require drupal/helfi_api_base:dev-UHF-10321`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that code follows our standards

Here is how I tested this:

* `drush upwd helfi-navigation 123`
* This command succeedes:
  ```
  curl -X POST http://helfi-etusivu:8080/fi/api/v1/global-menu/kuva \
	--user "helfi-navigation:123" \
	-H 'Content-Type: application/json' \
	-d '{ "site_name": "Kuva", "status": true, "menu_tree": { "name": "Kuva", "id": "base:kuva", "external": false, "hasItems": true, "weight": 0, "sub_tree": [] }}'
  ```
* This command fails (Because of `X-Forwarded-For` header):
  ```
  curl -X POST http://helfi-etusivu:8080/fi/api/v1/global-menu/kuva \
	--user "helfi-navigation:123" \
	-H 'Content-Type: application/json' \
	-H 'X-Forwarded-For: 123.123.123.123' \
	-d '{ "site_name": "Kuva", "status": true, "menu_tree": { "name": "Kuva", "id": "base:kuva", "external": false, "hasItems": true, "weight": 0, "sub_tree": [] }}'
  ```

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/1008


[UHF-10321]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ