### PR TITLE
UHF-12125 Project label contexts and translations

### DIFF
--- a/helfi_api_base.info.yml
+++ b/helfi_api_base.info.yml
@@ -8,3 +8,5 @@ dependencies:
   - monolog:monolog
   - health_check:health_check
   - raven:raven
+'interface translation project': helfi_api_base
+'interface translation server pattern': modules/contrib/helfi_api_base/translations/%language.po

--- a/src/Environment/Project.php
+++ b/src/Environment/Project.php
@@ -92,20 +92,20 @@ final class Project {
    */
   public function label() : TranslatableMarkup {
     return match ($this->name) {
-      self::ASUMINEN => new TranslatableMarkup('Housing'),
-      self::ETUSIVU => new TranslatableMarkup('Frontpage'),
-      self::KASVATUS_KOULUTUS => new TranslatableMarkup('Childhood and education'),
-      self::KUVA => new TranslatableMarkup('Culture and leisure'),
-      self::LIIKENNE => new TranslatableMarkup('Urban environment and traffic'),
-      self::REKRY => new TranslatableMarkup('Open jobs'),
-      self::STRATEGIA => new TranslatableMarkup('Decision-making'),
-      self::TERVEYS => new TranslatableMarkup('Health and social services'),
-      self::TYO_YRITTAMINEN => new TranslatableMarkup('Business and work'),
-      self::PAATOKSET => new TranslatableMarkup('Decisions'),
-      self::GRANTS => new TranslatableMarkup('Grants'),
-      self::PALVELUKESKUS => new TranslatableMarkup('Palvelukeskus'),
-      self::KAUPUNKITIETO => new TranslatableMarkup('Urban research and statistics'),
-      self::EMERGENCY_SITE => new TranslatableMarkup('Emergency site'),
+      self::ASUMINEN => new TranslatableMarkup('Housing', options: ['context' => 'project label']),
+      self::ETUSIVU => new TranslatableMarkup('Frontpage', options: ['context' => 'project label']),
+      self::KASVATUS_KOULUTUS => new TranslatableMarkup('Childhood and education', options: ['context' => 'project label']),
+      self::KUVA => new TranslatableMarkup('Culture and leisure', options: ['context' => 'project label']),
+      self::LIIKENNE => new TranslatableMarkup('Urban environment and traffic', options: ['context' => 'project label']),
+      self::REKRY => new TranslatableMarkup('Open jobs', options: ['context' => 'project label']),
+      self::STRATEGIA => new TranslatableMarkup('Decision-making', options: ['context' => 'project label']),
+      self::TERVEYS => new TranslatableMarkup('Health and social services', options: ['context' => 'project label']),
+      self::TYO_YRITTAMINEN => new TranslatableMarkup('Business and work', options: ['context' => 'project label']),
+      self::PAATOKSET => new TranslatableMarkup('Decisions', options: ['context' => 'project label']),
+      self::GRANTS => new TranslatableMarkup('Grants', options: ['context' => 'project label']),
+      self::PALVELUKESKUS => new TranslatableMarkup('Palvelukeskus', options: ['context' => 'project label']),
+      self::KAUPUNKITIETO => new TranslatableMarkup('Urban research and statistics', options: ['context' => 'project label']),
+      self::EMERGENCY_SITE => new TranslatableMarkup('Emergency site', options: ['context' => 'project label']),
     };
   }
 

--- a/src/Environment/Project.php
+++ b/src/Environment/Project.php
@@ -92,20 +92,20 @@ final class Project {
    */
   public function label() : TranslatableMarkup {
     return match ($this->name) {
-      self::ASUMINEN => new TranslatableMarkup('Housing', options: ['context' => 'project label']),
-      self::ETUSIVU => new TranslatableMarkup('Frontpage', options: ['context' => 'project label']),
-      self::KASVATUS_KOULUTUS => new TranslatableMarkup('Childhood and education', options: ['context' => 'project label']),
-      self::KUVA => new TranslatableMarkup('Culture and leisure', options: ['context' => 'project label']),
-      self::LIIKENNE => new TranslatableMarkup('Urban environment and traffic', options: ['context' => 'project label']),
-      self::REKRY => new TranslatableMarkup('Open jobs', options: ['context' => 'project label']),
-      self::STRATEGIA => new TranslatableMarkup('Decision-making', options: ['context' => 'project label']),
-      self::TERVEYS => new TranslatableMarkup('Health and social services', options: ['context' => 'project label']),
-      self::TYO_YRITTAMINEN => new TranslatableMarkup('Business and work', options: ['context' => 'project label']),
-      self::PAATOKSET => new TranslatableMarkup('Decisions', options: ['context' => 'project label']),
-      self::GRANTS => new TranslatableMarkup('Grants', options: ['context' => 'project label']),
-      self::PALVELUKESKUS => new TranslatableMarkup('Palvelukeskus', options: ['context' => 'project label']),
-      self::KAUPUNKITIETO => new TranslatableMarkup('Urban research and statistics', options: ['context' => 'project label']),
-      self::EMERGENCY_SITE => new TranslatableMarkup('Emergency site', options: ['context' => 'project label']),
+      self::ASUMINEN => new TranslatableMarkup('Housing', options: ['context' => 'Project label']),
+      self::ETUSIVU => new TranslatableMarkup('Frontpage', options: ['context' => 'Project label']),
+      self::KASVATUS_KOULUTUS => new TranslatableMarkup('Childhood and education', options: ['context' => 'Project label']),
+      self::KUVA => new TranslatableMarkup('Culture and leisure', options: ['context' => 'Project label']),
+      self::LIIKENNE => new TranslatableMarkup('Urban environment and traffic', options: ['context' => 'Project label']),
+      self::REKRY => new TranslatableMarkup('Open jobs', options: ['context' => 'Project label']),
+      self::STRATEGIA => new TranslatableMarkup('Decision-making', options: ['context' => 'Project label']),
+      self::TERVEYS => new TranslatableMarkup('Health and social services', options: ['context' => 'Project label']),
+      self::TYO_YRITTAMINEN => new TranslatableMarkup('Business and work', options: ['context' => 'Project label']),
+      self::PAATOKSET => new TranslatableMarkup('Decisions', options: ['context' => 'Project label']),
+      self::GRANTS => new TranslatableMarkup('Grants', options: ['context' => 'Project label']),
+      self::PALVELUKESKUS => new TranslatableMarkup('Palvelukeskus', options: ['context' => 'Project label']),
+      self::KAUPUNKITIETO => new TranslatableMarkup('Urban research and statistics', options: ['context' => 'Project label']),
+      self::EMERGENCY_SITE => new TranslatableMarkup('Emergency site', options: ['context' => 'Project label']),
     };
   }
 

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -1,0 +1,58 @@
+msgid ""
+msgstr ""
+
+msgctxt "Project label"
+msgid "Housing"
+msgstr "Asuminen"
+
+msgctxt "Project label"
+msgid "Frontpage"
+msgstr "Etusivu"
+
+msgctxt "Project label"
+msgid "Childhood and education"
+msgstr "Kasvatus ja koulutus"
+
+msgctxt "Project label"
+msgid "Culture and leisure"
+msgstr "Kulttuuri ja vapaa-aika"
+
+msgctxt "Project label"
+msgid "Urban environment and traffic"
+msgstr "Kaupunkiympäristö ja liikenne"
+
+msgctxt "Project label"
+msgid "Open jobs"
+msgstr "Avoimet työpaikat"
+
+msgctxt "Project label"
+msgid "Decision-making"
+msgstr "Päätöksenteko ja hallinto"
+
+msgctxt "Project label"
+msgid "Health and social services"
+msgstr "Sosiaali- ja terveyspalvelut"
+
+msgctxt "Project label"
+msgid "Business and work"
+msgstr "Yritykset ja työ"
+
+msgctxt "Project label"
+msgid "Decisions"
+msgstr "Päätökset"
+
+msgctxt "Project label"
+msgid "Grants"
+msgstr "Avustukset"
+
+msgctxt "Project label"
+msgid "Palvelukeskus"
+msgstr "Palvelukeskus"
+
+msgctxt "Project label"
+msgid "Urban research and statistics"
+msgstr "Kaupunkitieto"
+
+msgctxt "Project label"
+msgid "Emergency site"
+msgstr "Poikkeustilannesivusto"

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -1,0 +1,58 @@
+msgid ""
+msgstr ""
+
+msgctxt "Project label"
+msgid "Housing"
+msgstr "Boende"
+
+msgctxt "Project label"
+msgid "Frontpage"
+msgstr "Huvudsida"
+
+msgctxt "Project label"
+msgid "Childhood and education"
+msgstr "Fostran och utbildning"
+
+msgctxt "Project label"
+msgid "Culture and leisure"
+msgstr "Kultur och fritid"
+
+msgctxt "Project label"
+msgid "Urban environment and traffic"
+msgstr "Stadsmiljö och trafik"
+
+msgctxt "Project label"
+msgid "Open jobs"
+msgstr "Lediga jobb"
+
+msgctxt "Project label"
+msgid "Decision-making"
+msgstr "Beslutsfattande och förvaltning"
+
+msgctxt "Project label"
+msgid "Health and social services"
+msgstr "Social- och hälsovårdstjänster"
+
+msgctxt "Project label"
+msgid "Business and work"
+msgstr "Företag och arbete"
+
+msgctxt "Project label"
+msgid "Decisions"
+msgstr "Beslut"
+
+msgctxt "Project label"
+msgid "Grants"
+msgstr "Understöd"
+
+msgctxt "Project label"
+msgid "Palvelukeskus"
+msgstr "Palvelukeskus"
+
+msgctxt "Project label"
+msgid "Urban research and statistics"
+msgstr "Stadsforskning och -statistik"
+
+msgctxt "Project label"
+msgid "Emergency site"
+msgstr "Undantagswebbplats"


### PR DESCRIPTION
# [UHF-12125](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12125)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added contexts to project labels.
* Translated drupal instance names.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-12125`
  * `make fresh`
* Run `make drush-cr drush-locale-update`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check from `/admin/config/regional/translate` that the Finnish and Swedish translations for project labels exists
* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* tbd


[UHF-12125]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ