### PR TITLE
Restore default configuration before tearDown().

### DIFF
--- a/tests/src/Functional/ExistingSiteTestBase.php
+++ b/tests/src/Functional/ExistingSiteTestBase.php
@@ -27,8 +27,9 @@ abstract class ExistingSiteTestBase extends ExistingSiteBase {
    * {@inheritdoc}
    */
   public function tearDown() : void {
-    parent::tearDown();
     $this->tearDownDefaultConfiguration();
+
+    parent::tearDown();
   }
 
 }


### PR DESCRIPTION
Container is no longer available after parent::tearDown(), causing any configuration event subscribers to fail if they attempt to access the container.