### PR TITLE
UHF-13064: Filter backtrace from logs

### DIFF
--- a/src/HelfiApiBaseServiceProvider.php
+++ b/src/HelfiApiBaseServiceProvider.php
@@ -31,7 +31,6 @@ final class HelfiApiBaseServiceProvider extends ServiceProviderBase {
    */
   private function registerMonolog(ContainerBuilder $container): void {
     $monologProcessors = [
-      'message_placeholder',
       'current_user',
       'request_uri',
       'ip',
@@ -53,7 +52,7 @@ final class HelfiApiBaseServiceProvider extends ServiceProviderBase {
           [
             'name' => 'default_conditional_handler',
             'formatter' => 'drush_or_json',
-            'processors' => $monologProcessors,
+            'processors' => array_merge(['message_placeholder'], $monologProcessors),
           ],
         ],
       ],

--- a/src/HelfiApiBaseServiceProvider.php
+++ b/src/HelfiApiBaseServiceProvider.php
@@ -36,6 +36,7 @@ final class HelfiApiBaseServiceProvider extends ServiceProviderBase {
       'ip',
       'referer',
       'logger_context',
+      'filter_backtrace',
     ];
 
     $container->setParameter('monolog.channel_handlers', [
@@ -45,13 +46,8 @@ final class HelfiApiBaseServiceProvider extends ServiceProviderBase {
             // The Raven logger handler must be added to forward log messages
             // to Sentry. We remove the `message_placeholder` processor from
             // the default processors, as Raven already handles placeholders.
-            // NOTE: The `filter_backtrace` processor should be included.
-            // Without it, logging long backtraces may lead to out-of-memory
-            // errors.
             'name' => 'drupal.raven',
-            'processors' => array_merge($monologProcessors, [
-              'filter_backtrace',
-            ]),
+            'processors' => $monologProcessors,
           ],
           [
             'name' => 'default_conditional_handler',

--- a/src/HelfiApiBaseServiceProvider.php
+++ b/src/HelfiApiBaseServiceProvider.php
@@ -31,6 +31,7 @@ final class HelfiApiBaseServiceProvider extends ServiceProviderBase {
    */
   private function registerMonolog(ContainerBuilder $container): void {
     $monologProcessors = [
+      'message_placeholder',
       'current_user',
       'request_uri',
       'ip',


### PR DESCRIPTION
## How to install 
- `composer require drupal/helfi_api_base:dev-UHF-13064`

## How to test
* [ ] Add an error that triggers a warning on some page, like `$x = $array['x'];`
* [ ] Check the logs (`docker compose logs app`) and verify the error backtrace is visible, but excludes metadata such as controller response or render array data