### PR TITLE
UHF-13214: Sanitize address for Service Map API

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -586,16 +586,6 @@ parameters:
 			path: src/Plugin/migrate/source/HttpSourcePluginBase.php
 
 		-
-			message: "#^Method Drupal\\\\helfi_api_base\\\\ServiceMap\\\\DTO\\\\Location\\:\\:createFromArray\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/ServiceMap/DTO/Location.php
-
-		-
-			message: "#^Method Drupal\\\\helfi_api_base\\\\ServiceMap\\\\DTO\\\\StreetName\\:\\:createFromArray\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/ServiceMap/DTO/StreetName.php
-
-		-
 			message: "#^Parameter \\#2 \\$uid of function user_cancel expects int, string given\\.$#"
 			count: 1
 			path: src/UserExpire/UserExpireManager.php
@@ -896,27 +886,7 @@ parameters:
 			path: tests/src/Kernel/ServiceMap/ServiceMapTest.php
 
 		-
-			message: "#^Method Drupal\\\\Tests\\\\helfi_api_base\\\\Kernel\\\\ServiceMap\\\\ServiceMapTest\\:\\:getSut\\(\\) has parameter \\$client with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy but does not specify its types\\: T$#"
-			count: 1
-			path: tests/src/Kernel/ServiceMap/ServiceMapTest.php
-
-		-
-			message: "#^Method Drupal\\\\Tests\\\\helfi_api_base\\\\Kernel\\\\ServiceMap\\\\ServiceMapTest\\:\\:getSut\\(\\) has parameter \\$logger with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy but does not specify its types\\: T$#"
-			count: 1
-			path: tests/src/Kernel/ServiceMap/ServiceMapTest.php
-
-		-
 			message: "#^Method class@anonymous/tests/src/Traits/ApiTestTrait\\.php\\:57\\:\\:fromOptions\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/src/Kernel/ServiceMap/ServiceMapTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$client of class Drupal\\\\helfi_api_base\\\\ServiceMap\\\\ServiceMap constructor expects GuzzleHttp\\\\Client, object given\\.$#"
-			count: 1
-			path: tests/src/Kernel/ServiceMap/ServiceMapTest.php
-
-		-
-			message: "#^Parameter \\#3 \\$logger of class Drupal\\\\helfi_api_base\\\\ServiceMap\\\\ServiceMap constructor expects Psr\\\\Log\\\\LoggerInterface, object given\\.$#"
 			count: 1
 			path: tests/src/Kernel/ServiceMap/ServiceMapTest.php
 

--- a/src/ServiceMap/DTO/Location.php
+++ b/src/ServiceMap/DTO/Location.php
@@ -32,7 +32,7 @@ final readonly class Location {
   /**
    * Creates a Location instance from an associative array.
    *
-   * @param array $data
+   * @param array<mixed> $data
    *   An associative array containing:
    *   - coordinates: An indexed array where the first element is the
    *     longitude and the second is the latitude.

--- a/src/ServiceMap/DTO/StreetName.php
+++ b/src/ServiceMap/DTO/StreetName.php
@@ -26,7 +26,7 @@ final readonly class StreetName {
    * will be populated using a corresponding key from the input array, or
    * fallback to the 'fi' value if the key is not present.
    *
-   * @param array $data
+   * @param array<mixed> $data
    *   An associative array containing:
    *   - fi: The default value to use for any property not explicitly set.
    *   - <property_name>: (optional) Values for specific class properties.

--- a/src/ServiceMap/ServiceMap.php
+++ b/src/ServiceMap/ServiceMap.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\helfi_api_base\ServiceMap;
 
-use Drupal\Component\Utility\Xss;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Utility\Error;
@@ -33,9 +32,9 @@ final class ServiceMap implements ServiceMapInterface {
   /**
    * Constructs a new instance.
    *
-   * @param \GuzzleHttp\Client $client
+   * @param \GuzzleHttp\ClientInterface $client
    *   The HTTP client.
-   * @param \Drupal\Core\Language\LanguageManager $languageManager
+   * @param \Drupal\Core\Language\LanguageManagerInterface $languageManager
    *   Language manager.
    * @param \Psr\Log\LoggerInterface $logger
    *   Logger.
@@ -62,10 +61,26 @@ final class ServiceMap implements ServiceMapInterface {
   }
 
   /**
+   * Sanitizes the given address.
+   *
+   * @param string $address
+   *   The address.
+   *
+   * @return string|null
+   *   The sanitized address.
+   */
+  public function sanitizeAddress(string $address) : ?string {
+    // ServiceMap API only allows letters, numbers, spaces and .,'+-&|.
+    // \p{L} - Unicode letters (a-z, A-Z, ä, ö, å, etc.)
+    // \p{N} - Unicode numbers (0-9).
+    return preg_replace("/[^\p{L}\p{N} .,'+\-&|]/u", '', $address);
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function query(string $address, int $page_size = 1) : array {
-    $address = Xss::filter($address);
+    $address = $this->sanitizeAddress($address);
 
     try {
       $response = $this->client->request('GET', self::API_URL, [

--- a/tests/src/Kernel/ServiceMap/ServiceMapTest.php
+++ b/tests/src/Kernel/ServiceMap/ServiceMapTest.php
@@ -38,9 +38,9 @@ class ServiceMapTest extends KernelTestBase {
   /**
    * Gets the SUT.
    *
-   * @param \Prophecy\Prophecy\ObjectProphecy $client
+   * @param \Prophecy\Prophecy\ObjectProphecy<\GuzzleHttp\ClientInterface> $client
    *   The client mock.
-   * @param \Prophecy\Prophecy\ObjectProphecy $logger
+   * @param \Prophecy\Prophecy\ObjectProphecy<\Psr\Log\LoggerInterface> $logger
    *   The logger mock.
    *
    * @return \Drupal\helfi_api_base\ServiceMap\ServiceMap

--- a/tests/src/Unit/ServiceMap/AddressSanitizeTest.php
+++ b/tests/src/Unit/ServiceMap/AddressSanitizeTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_api_base\Unit\ServiceMap;
+
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\helfi_api_base\ServiceMap\ServiceMap;
+use Drupal\Tests\UnitTestCase;
+use GuzzleHttp\ClientInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests Address sanitization regex.
+ */
+#[Group('helfi_api_base')]
+class AddressSanitizeTest extends UnitTestCase {
+
+  /**
+   * Sanitized the given string.
+   *
+   * @param string $input
+   *   The input.
+   *
+   * @return string
+   *   The sanitized string.
+   */
+  private function sanitize(string $input): string {
+    $serviceMap = new ServiceMap(
+      $this->prophesize(ClientInterface::class)->reveal(),
+      $this->prophesize(LanguageManagerInterface::class)->reveal(),
+      $this->prophesize(LoggerInterface::class)->reveal(),
+    );
+    return $serviceMap->sanitizeAddress($input);
+  }
+
+  /**
+   * Tests that allowed characters are preserved.
+   */
+  #[DataProvider('allowedCharactersProvider')]
+  public function testAllowedCharactersArePreserved(string $input): void {
+    $this->assertSame($input, $this->sanitize($input));
+  }
+
+  /**
+   * Data provider for allowed characters.
+   *
+   * @return array<mixed>
+   *   The test data.
+   */
+  public static function allowedCharactersProvider(): array {
+    return [
+      'ascii letters' => ['Hello World'],
+      'numbers' => ['abc 123'],
+      'dot' => ['e.g. something'],
+      'comma' => ['one, two, three'],
+      'single quote' => ["it's fine"],
+      'plus' => ['a+b'],
+      'minus' => ['a-b'],
+      'ampersand' => ['cats & dogs'],
+      'pipe' => ['a|b'],
+      'unicode letters fi' => ['ääkköset öljy'],
+      'unicode letters sv' => ['åland'],
+      'cyrillic letters' => ['Привет мир'],
+      'mixed allowed' => ["Hello, it's a test +1 & more | less-done."],
+    ];
+  }
+
+  /**
+   * Tests that disallowed characters are removed.
+   */
+  #[DataProvider('disallowedCharactersProvider')]
+  public function testDisallowedCharactersAreRemoved(string $input, string $expected): void {
+    $this->assertSame($expected, $this->sanitize($input));
+  }
+
+  /**
+   * Data provider for disallowed characters.
+   *
+   * @return array<mixed>
+   *   The data.
+   */
+  public static function disallowedCharactersProvider(): array {
+    return [
+      'exclamation mark' => ['Hello!', 'Hello'],
+      'at sign' => ['user@example.com', 'userexample.com'],
+      'hash' => ['#tag', 'tag'],
+      'dollar' => ['$100', '100'],
+      'percent' => ['50%', '50'],
+      'caret' => ['a^b', 'ab'],
+      'asterisk' => ['a*b', 'ab'],
+      'parentheses' => ['(test)', 'test'],
+      'brackets' => ['[test]', 'test'],
+      'curly braces' => ['{test}', 'test'],
+      'backslash' => ['a\\b', 'ab'],
+      'forward slash' => ['a/b', 'ab'],
+      'question mark' => ['why?', 'why'],
+      'colon' => ['a:b', 'ab'],
+      'semicolon' => ['a;b', 'ab'],
+      'less than' => ['a<b', 'ab'],
+      'greater than' => ['a>b', 'ab'],
+      'tilde' => ['a~b', 'ab'],
+      'backtick' => ['a`b', 'ab'],
+      'tab' => ["a\tb", 'ab'],
+      'newline' => ["a\nb", 'ab'],
+      'mixed disallowed' => ['Hello! @world#', 'Hello world'],
+    ];
+  }
+
+  /**
+   * Tests empty string.
+   */
+  public function testEmptyStringReturnsEmpty(): void {
+    $this->assertSame('', $this->sanitize(''));
+  }
+
+  /**
+   * Tests string with only disallowed characters.
+   */
+  public function testAllDisallowedReturnsEmpty(): void {
+    $this->assertSame('', $this->sanitize('!@#$%^*()'));
+  }
+
+}


### PR DESCRIPTION
# [UHF-13214](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13214)

## What was done

* Filtered out non-Unicode letters and numbers from Service Map addresses.

## How to install

* Update the Helfi API Base module:

  * `composer require drupal/helfi_api_base:dev-UHF-13214`
* Start the Etusivu instance.

## How to test

* [ ] Open `/en/helsinki-near-you`
* [ ] Enter a valid address (for example, `Pasilankatu 2`) and verify that results are returned
* [ ] Enter non-allowed characters into the address field and verify that no `GuzzleException` errors appear in the logs (`docker compose logs app tail -f`)


[UHF-13214]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ