### PR TITLE
UHF-13336: as stated in raven documentation, filter_backtrace processor should not be enabled

### DIFF
--- a/src/HelfiApiBaseServiceProvider.php
+++ b/src/HelfiApiBaseServiceProvider.php
@@ -40,7 +40,6 @@ final class HelfiApiBaseServiceProvider extends ServiceProviderBase {
       'ip',
       'referer',
       'logger_context',
-      'filter_backtrace',
     ];
 
     $container->setParameter('monolog.channel_handlers', [
@@ -56,7 +55,7 @@ final class HelfiApiBaseServiceProvider extends ServiceProviderBase {
           [
             'name' => 'default_conditional_handler',
             'formatter' => 'drush_or_json',
-            'processors' => array_merge(['message_placeholder'], $monologProcessors),
+            'processors' => array_merge(['message_placeholder', 'filter_backtrace'], $monologProcessors),
           ],
         ],
       ],


### PR DESCRIPTION
filter_backtrace or message_placeholder should not be enabled, as stated here https://git.drupalcode.org/project/raven#monolog-module-integration