### PR TITLE
UHF-13336: add the eventsubscriber to alter sentry messages

### DIFF
--- a/documentation/sentry-errors.md
+++ b/documentation/sentry-errors.md
@@ -15,4 +15,4 @@ Add a part of the error message to the ignoredErrors-array to ignore the error.
 
 ### Rate limiting
 
-Add an error to the rate limiting array to reduce the amount of errors sent to sentry.
+Add an error to the sampleRate -array to reduce the amount of errors sent to sentry.

--- a/documentation/sentry-errors.md
+++ b/documentation/sentry-errors.md
@@ -1,4 +1,4 @@
-#Sentry errors
+# Sentry errors
 
 ## Sentry options alter event subscriber
 

--- a/documentation/sentry-errors.md
+++ b/documentation/sentry-errors.md
@@ -12,3 +12,7 @@ Sentry uses fingerprints to group similar errors under one item.
 
 Uses str_contains to decide whether to send the error to Sentry or not.
 Add a part of the error message to the ignoredErrors-array to ignore the error.
+
+### Rate limiting
+
+Add an error to the rate limiting array to reduce the amount of errors sent to sentry.

--- a/documentation/sentry-errors.md
+++ b/documentation/sentry-errors.md
@@ -1,0 +1,14 @@
+#Sentry errors
+
+## Sentry options alter event subscriber
+
+Use SentryOptionsAlterEventSubscriber to alter or ignore errors sent to Sentry
+
+### Fingerprint rules
+
+Sentry uses fingerprints to group similar errors under one item.
+
+### Ignored errors
+
+Uses str_contains to decide whether to send the error to Sentry or not.
+Add a part of the error message to the ignoredErrors-array to ignore the error.

--- a/helfi_api_base.services.yml
+++ b/helfi_api_base.services.yml
@@ -33,6 +33,7 @@ services:
       - { name: http_middleware, priority: 250 }
 
   Drupal\helfi_api_base\UserExpire\UserExpireManager: ~
+  Drupal\helfi_api_base\EventSubscriber\SentryOptionsAlterEventSubscriber: ~
   Drupal\helfi_api_base\EventSubscriber\SentryTracesSamplerSubscriber: ~
   Drupal\helfi_api_base\EventSubscriber\DisableUserPasswordSubscriber: ~
 

--- a/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
+++ b/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
@@ -33,20 +33,53 @@ final class SentryOptionsAlterEventSubscriber implements EventSubscriberInterfac
   ];
 
   /**
+   * Array of sample rates.
+   *
+   * @var array|array[]
+   */
+  private array $sampleRates = [
+    '0.1' => [
+      'cURL error 6: Could not resolve host: helfi-etusivu'
+    ],
+  ];
+
+  /**
    * Alter the Sentry client options.
    */
   public function alterOptions(OptionsAlter $optionsAlterEvent) : void {
     $optionsAlterEvent->options['before_send'] = function (Event $event): ?Event {
+      $eventErrorMessage = $event->getMessageFormatted();
+
       // Alter fingerprint: Fingerprint is used by Sentry to group errors.
       $event->setFingerprint($this->fingerprintRules);
 
       // Ignore errors.
-      if (array_any($this->ignoredErrors, fn($message) => str_contains($event->getMessageFormatted(), $message))) {
+      if (array_any($this->ignoredErrors, fn($message) => str_contains($eventErrorMessage, $message))) {
         return NULL;
+      }
+
+      // Check if the error should be rate limited.
+      foreach($this->sampleRates as $rate => $rates) {
+        if(array_any($rates, fn($message) => str_contains($eventErrorMessage, $message))) {
+          return $this->customRateLimiter(floatval($rate)) ? $event : NULL;
+        }
       }
 
       return $event;
     };
+  }
+
+  /**
+   * Limit the amount of errors sent.
+   *
+   * @param $rate
+   *   The amount of errors to send to sentry.
+   *
+   * @return bool
+   *   Error should be sent to sentry.
+   */
+  private function customRateLimiter(float $rate): bool {
+    return (mt_rand() / mt_getrandmax()) <= $rate;
   }
 
   /**

--- a/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
+++ b/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
@@ -55,8 +55,6 @@ final class SentryOptionsAlterEventSubscriber implements EventSubscriberInterfac
         return NULL;
       }
 
-
-
       // Handle rate limited errors.
       foreach ($this->sampleRates as $message => $rateLimit) {
         if (str_contains($eventErrorMessage, $message) && $this->skipErrorByRateLimit($rateLimit)) {

--- a/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
+++ b/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
@@ -72,7 +72,7 @@ final class SentryOptionsAlterEventSubscriber implements EventSubscriberInterfac
   /**
    * Limit the amount of errors sent.
    *
-   * @param $rate
+   * @param float $rate
    *   The amount of errors to send to sentry.
    *
    * @return bool

--- a/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
+++ b/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
@@ -27,9 +27,10 @@ final class SentryOptionsAlterEventSubscriber implements EventSubscriberInterfac
 
       // Exclude error messages.
       $excludeByMessage = [
-        'No alive nodes. All the 1 nodes seem to be down'
+        'No alive nodes. All the 1 nodes seem to be down',
+        'cURL error 6: Could not resolve host: helfi-etusivu',
       ];
-      if (array_any($excludeByMessage, fn($message) => str_contains($event->getMessage(), $message))) {
+      if (array_any($excludeByMessage, fn($message) => str_contains($event->getMessageFormatted(), $message))) {
         return NULL;
       }
 

--- a/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
+++ b/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
@@ -17,7 +17,7 @@ final class SentryOptionsAlterEventSubscriber implements EventSubscriberInterfac
    * Information is used by Sentry to group errors.
    *
    * @var array|string[]
-   */T
+   */
   private array $fingerprintRules = [
     'error.type:"*" -> group-by-exception-then-message, #{{ error.type }}, #{{ error.value }}',
   ];

--- a/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
+++ b/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
@@ -17,7 +17,7 @@ final class SentryOptionsAlterEventSubscriber implements EventSubscriberInterfac
    * Information is used by Sentry to group errors.
    *
    * @var array|string[]
-   */
+   */T
   private array $fingerprintRules = [
     'error.type:"*" -> group-by-exception-then-message, #{{ error.type }}, #{{ error.value }}',
   ];
@@ -34,7 +34,7 @@ final class SentryOptionsAlterEventSubscriber implements EventSubscriberInterfac
   /**
    * Array of sample rates.
    *
-   * @var array|array[]
+   * @var array|string[]
    */
   private array $sampleRates = [
     '0.1' => [
@@ -57,7 +57,7 @@ final class SentryOptionsAlterEventSubscriber implements EventSubscriberInterfac
         return NULL;
       }
 
-      // Check if the error should be rate limited.
+      // Handle rate limited errors.
       foreach ($this->sampleRates as $rate => $rates) {
         if (array_any($rates, fn($message) => str_contains($eventErrorMessage, $message))) {
           return $this->customRateLimiter(floatval($rate)) ? $event : NULL;

--- a/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
+++ b/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_api_base\EventSubscriber;
+
+use Drupal\raven\Event\OptionsAlter;
+use Sentry\Event;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+
+/**
+ * Allow altering sentry errors before sending.
+ */
+final class SentryOptionsAlterEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Alter the Sentry client options.
+   */
+  public function alterOptions(OptionsAlter $optionsAlterEvent) : void {
+    $optionsAlterEvent->options['before_send'] = function (Event $event): ?Event {
+      // Alter fingerprint: Fingerprint is used by Sentry to group errors.
+      $fingerprints = [
+        'error.type:"*" -> group-by-exception-then-message, #{{ error.type }}, #{{ error.value }}'
+      ];
+      $event->setFingerprint($fingerprints);
+
+      // Exclude error messages.
+      $excludeByMessage = [
+        'No alive nodes. All the 1 nodes seem to be down'
+      ];
+      if (array_any($excludeByMessage, fn($message) => str_contains($event->getMessage(), $message))) {
+        return NULL;
+      }
+
+      return $event;
+    };
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() : array {
+    return [
+      OptionsAlter::class => ['alterOptions'],
+    ];
+  }
+
+}

--- a/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
+++ b/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
@@ -37,9 +37,7 @@ final class SentryOptionsAlterEventSubscriber implements EventSubscriberInterfac
    * @var array|string[]
    */
   private array $sampleRates = [
-    '0.1' => [
-      'cURL error 6: Could not resolve host: helfi-etusivu',
-    ],
+    'cURL error 6: Could not resolve host: helfi-etusivu' => 0.1,
   ];
 
   /**
@@ -57,10 +55,12 @@ final class SentryOptionsAlterEventSubscriber implements EventSubscriberInterfac
         return NULL;
       }
 
+
+
       // Handle rate limited errors.
-      foreach ($this->sampleRates as $rate => $rates) {
-        if (array_any($rates, fn($message) => str_contains($eventErrorMessage, $message))) {
-          return $this->customRateLimiter(floatval($rate)) ? $event : NULL;
+      foreach ($this->sampleRates as $message => $rateLimit) {
+        if (str_contains($eventErrorMessage, $message) && $this->skipErrorByRateLimit($rateLimit)) {
+          return NULL;
         }
       }
 
@@ -75,10 +75,11 @@ final class SentryOptionsAlterEventSubscriber implements EventSubscriberInterfac
    *   The amount of errors to send to sentry.
    *
    * @return bool
-   *   Error should be sent to sentry.
+   *   Error should be skipped.
    */
-  private function customRateLimiter(float $rate): bool {
-    return (mt_rand() / mt_getrandmax()) <= $rate;
+  private function skipErrorByRateLimit(float $rate): bool {
+    // If the random float is bigger than given limit, skip the error.
+    return (mt_rand() / mt_getrandmax()) > $rate;
   }
 
   /**

--- a/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
+++ b/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
@@ -8,7 +8,6 @@ use Drupal\raven\Event\OptionsAlter;
 use Sentry\Event;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-
 /**
  * Allow altering sentry errors before sending.
  */
@@ -20,7 +19,7 @@ final class SentryOptionsAlterEventSubscriber implements EventSubscriberInterfac
    * @var array|string[]
    */
   private array $fingerprintRules = [
-    'error.type:"*" -> group-by-exception-then-message, #{{ error.type }}, #{{ error.value }}'
+    'error.type:"*" -> group-by-exception-then-message, #{{ error.type }}, #{{ error.value }}',
   ];
 
   /**
@@ -39,7 +38,7 @@ final class SentryOptionsAlterEventSubscriber implements EventSubscriberInterfac
    */
   private array $sampleRates = [
     '0.1' => [
-      'cURL error 6: Could not resolve host: helfi-etusivu'
+      'cURL error 6: Could not resolve host: helfi-etusivu',
     ],
   ];
 
@@ -59,8 +58,8 @@ final class SentryOptionsAlterEventSubscriber implements EventSubscriberInterfac
       }
 
       // Check if the error should be rate limited.
-      foreach($this->sampleRates as $rate => $rates) {
-        if(array_any($rates, fn($message) => str_contains($eventErrorMessage, $message))) {
+      foreach ($this->sampleRates as $rate => $rates) {
+        if (array_any($rates, fn($message) => str_contains($eventErrorMessage, $message))) {
           return $this->customRateLimiter(floatval($rate)) ? $event : NULL;
         }
       }

--- a/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
+++ b/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
@@ -15,22 +15,33 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 final class SentryOptionsAlterEventSubscriber implements EventSubscriberInterface {
 
   /**
+   * Information is used by Sentry to group errors.
+   *
+   * @var array|string[]
+   */
+  private array $fingerprintRules = [
+    'error.type:"*" -> group-by-exception-then-message, #{{ error.type }}, #{{ error.value }}'
+  ];
+
+  /**
+   * List of errors to ignore.
+   *
+   * @var array|string[]
+   */
+  private array $ignoredErrors = [
+    'No alive nodes. All the 1 nodes seem to be down',
+  ];
+
+  /**
    * Alter the Sentry client options.
    */
   public function alterOptions(OptionsAlter $optionsAlterEvent) : void {
     $optionsAlterEvent->options['before_send'] = function (Event $event): ?Event {
       // Alter fingerprint: Fingerprint is used by Sentry to group errors.
-      $fingerprints = [
-        'error.type:"*" -> group-by-exception-then-message, #{{ error.type }}, #{{ error.value }}'
-      ];
-      $event->setFingerprint($fingerprints);
+      $event->setFingerprint($this->fingerprintRules);
 
-      // Exclude error messages.
-      $excludeByMessage = [
-        'No alive nodes. All the 1 nodes seem to be down',
-        'cURL error 6: Could not resolve host: helfi-etusivu',
-      ];
-      if (array_any($excludeByMessage, fn($message) => str_contains($event->getMessageFormatted(), $message))) {
+      // Ignore errors.
+      if (array_any($this->ignoredErrors, fn($message) => str_contains($event->getMessageFormatted(), $message))) {
         return NULL;
       }
 

--- a/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
+++ b/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
@@ -45,7 +45,7 @@ final class SentryOptionsAlterEventSubscriber implements EventSubscriberInterfac
    */
   public function alterOptions(OptionsAlter $optionsAlterEvent) : void {
     $optionsAlterEvent->options['before_send'] = function (Event $event): ?Event {
-      $eventErrorMessage = $event->getMessageFormatted();
+      $eventErrorMessage = $event->getMessageFormatted() ?? '';
 
       // Alter fingerprint: Fingerprint is used by Sentry to group errors.
       $event->setFingerprint($this->fingerprintRules);

--- a/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
+++ b/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
@@ -77,7 +77,7 @@ final class SentryOptionsAlterEventSubscriber implements EventSubscriberInterfac
    */
   private function skipErrorByRateLimit(float $rate): bool {
     // If the random float is bigger than given limit, skip the error.
-    return (mt_rand() / mt_getrandmax()) > $rate;
+    return (mt_rand() / mt_getrandmax()) > $rate; // NOSONAR
   }
 
   /**

--- a/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
+++ b/src/EventSubscriber/SentryOptionsAlterEventSubscriber.php
@@ -34,7 +34,7 @@ final class SentryOptionsAlterEventSubscriber implements EventSubscriberInterfac
   /**
    * Array of sample rates.
    *
-   * @var array|string[]
+   * @var array<string,float>
    */
   private array $sampleRates = [
     'cURL error 6: Could not resolve host: helfi-etusivu' => 0.1,

--- a/tests/src/Kernel/EventSubscriber/SentryOptionsAlterSubscriberTest.php
+++ b/tests/src/Kernel/EventSubscriber/SentryOptionsAlterSubscriberTest.php
@@ -1,0 +1,66 @@
+<?php
+
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_api_base\Kernel\EventSubscriber;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\raven\Event\OptionsAlter;
+use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
+use Sentry\Event;
+
+/**
+ * Tests our custom options alter event subscriber.
+ */
+class SentryOptionsAlterSubscriberTest extends KernelTestBase {
+
+  use ApiTestTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'user',
+    'raven',
+    'diff',
+    'helfi_api_base'
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installConfig('helfi_api_base');
+  }
+
+  /**
+   * Test that ignoring errors work.
+   */
+  public function testOptionsAlter(): void {
+    $dispatcher = $this->container->get('event_dispatcher');
+
+    $options = [];
+    $event = new OptionsAlter($options);
+    $dispatcher->dispatch($event);
+
+    $this->assertArrayHasKey('before_send', $event->options);
+    $this->assertIsCallable($event->options['before_send']);
+
+    $sentry_event = Event::createEvent();
+
+    // Test that ignored error is ignored
+    $sentry_event->setMessage('', [], 'No alive nodes. All the 1 nodes seem to be down');
+    $result = ($event->options['before_send'])($sentry_event);
+    $this->assertNull($result);
+
+    // Test message which is not in ignore list.
+    $sentry_event = Event::createEvent();
+    $sentry_event->setMessage('', [], 'This should not be ignored (result not null)');
+    $result = ($event->options['before_send'])($sentry_event);
+    $this->assertSame($sentry_event, $result);
+  }
+
+}

--- a/tests/src/Kernel/EventSubscriber/SentryOptionsAlterSubscriberTest.php
+++ b/tests/src/Kernel/EventSubscriber/SentryOptionsAlterSubscriberTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Drupal\Tests\helfi_api_base\Kernel\EventSubscriber;
@@ -24,7 +23,7 @@ class SentryOptionsAlterSubscriberTest extends KernelTestBase {
     'user',
     'raven',
     'diff',
-    'helfi_api_base'
+    'helfi_api_base',
   ];
 
   /**
@@ -51,7 +50,7 @@ class SentryOptionsAlterSubscriberTest extends KernelTestBase {
 
     $sentry_event = Event::createEvent();
 
-    // Test that ignored error is ignored
+    // Test that ignored error is ignored.
     $sentry_event->setMessage('', [], 'No alive nodes. All the 1 nodes seem to be down');
     $result = ($event->options['before_send'])($sentry_event);
     $this->assertNull($result);


### PR DESCRIPTION
# [UHF-13336](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13336)

## What was done
- Added event listener 
  - Ignoring errors by error message (uses str_contains)
  - Rate limit errors by error message (also uses str_contains) 
  - Testing custom fingerprint, allows sentry to group the errors by errortype + error message instead of the sentrys default algorithm which causes duplicate items for same error.

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running on latest dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Update the Helfi API Base module
  * `composer require drupal/helfi_api_base:dev-UHF-13336`
* Run code updates
  * `composer install`
  * `make drush-updb drush-locale-update drush-cr`

## How to test
- Setup sentry by adding SENTRY_DSN composer.yaml (check dev.azure for correct value)
- If you don't have front page up and running, loading any instances front page should send message to Sentry 
- Go to sentry and find one of the errors sent from local (the app env might be "prod" when sending from local)
- Open the Error  one of the errors, scroll all the way down and find Event Grouping Information
  - You should see "custom server fingerprint"
- You can try adding the error to the ignore-array and refresh the page and see that the error is not sent any more. 


[UHF-13336]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ